### PR TITLE
Set quality/directional_shadow/size=16384

### DIFF
--- a/src/project.godot
+++ b/src/project.godot
@@ -152,6 +152,5 @@ nextTable={
 [rendering]
 
 threads/thread_model=2
-quality/directional_shadow/size=16384
 quality/filters/msaa=2
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
Lowering to default value of 4094 to prevent GL_OUT_OF_MEMORY in glTexImage2D

This happens on my radeon card (r600 on linux).
Having a godot default here improves compatibility.

As a moving forward activity, more renderer things can be made configurable. (eg: FSAA 4x by default is a bit heavy)
Anything against receiving pull requests in that direction?