### PR TITLE
Extract settings menu scene

### DIFF
--- a/src/addons/Libre_Train_Sim_Editor/Data/Modules/MainMenu.tscn
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Modules/MainMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Scripts/MainMenu.gd" type="Script" id=1]
 [ext_resource path="res://screenshot.png" type="Texture" id=2]
@@ -6,6 +6,7 @@
 [ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Misc/FontMenu.tres" type="DynamicFont" id=4]
 [ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Misc/FontMedium.tres" type="DynamicFont" id=5]
 [ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Misc/follow-that-dream-by-luca-fraula-from-filmmusic-io.ogg" type="AudioStream" id=6]
+[ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Modules/SettingsMenu.tscn" type="PackedScene" id=7]
 
 [node name="MainMenu" type="Control"]
 anchor_right = 1.0
@@ -344,142 +345,8 @@ size_flags_horizontal = 3
 custom_fonts/font = ExtResource( 5 )
 text = "Reload"
 
-[node name="Settings" type="VBoxContainer" parent="."]
+[node name="Settings" parent="." instance=ExtResource( 7 )]
 visible = false
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 25.0
-margin_top = 13.0
-margin_right = -29.0
-margin_bottom = -24.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Label" type="Label" parent="Settings"]
-margin_right = 970.0
-margin_bottom = 45.0
-custom_fonts/font = ExtResource( 5 )
-text = "Settings:"
-align = 1
-
-[node name="Control" type="Control" parent="Settings"]
-margin_top = 49.0
-margin_right = 970.0
-margin_bottom = 220.0
-size_flags_vertical = 3
-
-[node name="GridContainer" type="GridContainer" parent="Settings"]
-margin_left = 400.0
-margin_top = 224.0
-margin_right = 569.0
-margin_bottom = 332.0
-size_flags_horizontal = 4
-columns = 2
-
-[node name="Label" type="Label" parent="Settings/GridContainer"]
-margin_top = 5.0
-margin_right = 91.0
-margin_bottom = 19.0
-text = "Fullscreen"
-
-[node name="Fullscreen" type="CheckBox" parent="Settings/GridContainer"]
-margin_left = 120.0
-margin_right = 144.0
-margin_bottom = 24.0
-size_flags_horizontal = 4
-
-[node name="Label6" type="Label" parent="Settings/GridContainer"]
-margin_left = 120.0
-margin_right = 160.0
-margin_bottom = 14.0
-text = "Music"
-
-[node name="MainMenuMusic" type="CheckBox" parent="Settings/GridContainer"]
-margin_left = 120.0
-margin_right = 144.0
-margin_bottom = 24.0
-size_flags_horizontal = 4
-
-[node name="Label2" type="Label" parent="Settings/GridContainer"]
-margin_top = 33.0
-margin_right = 91.0
-margin_bottom = 47.0
-text = "Shadows"
-
-[node name="Shadows" type="CheckBox" parent="Settings/GridContainer"]
-margin_left = 120.0
-margin_top = 28.0
-margin_right = 144.0
-margin_bottom = 52.0
-size_flags_horizontal = 4
-
-[node name="Label3" type="Label" parent="Settings/GridContainer"]
-margin_top = 61.0
-margin_right = 91.0
-margin_bottom = 75.0
-text = "View-Distance"
-
-[node name="ViewDistance" type="SpinBox" parent="Settings/GridContainer"]
-margin_left = 95.0
-margin_top = 56.0
-margin_right = 169.0
-margin_bottom = 80.0
-min_value = 250.0
-max_value = 1000.0
-value = 1000.0
-suffix = "m"
-
-[node name="Label4" type="Label" parent="Settings/GridContainer"]
-margin_top = 89.0
-margin_right = 91.0
-margin_bottom = 103.0
-text = "Anti Aliasing"
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="AntiAliasing" type="CheckBox" parent="Settings/GridContainer"]
-margin_left = 120.0
-margin_top = 84.0
-margin_right = 144.0
-margin_bottom = 108.0
-size_flags_horizontal = 4
-
-[node name="Label5" type="Label" parent="Settings/GridContainer"]
-margin_top = 89.0
-margin_right = 91.0
-margin_bottom = 103.0
-text = "Fog"
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Fog" type="CheckBox" parent="Settings/GridContainer"]
-margin_left = 120.0
-margin_top = 84.0
-margin_right = 144.0
-margin_bottom = 108.0
-size_flags_horizontal = 4
-
-[node name="Control2" type="Control" parent="Settings"]
-margin_top = 336.0
-margin_right = 970.0
-margin_bottom = 508.0
-size_flags_vertical = 3
-
-[node name="Buttons" type="HBoxContainer" parent="Settings"]
-margin_top = 512.0
-margin_right = 970.0
-margin_bottom = 563.0
-
-[node name="Back" type="Button" parent="Settings/Buttons"]
-margin_right = 970.0
-margin_bottom = 51.0
-rect_min_size = Vector2( 200, 0 )
-size_flags_horizontal = 3
-custom_fonts/font = ExtResource( 5 )
-text = "Back"
 
 [node name="Loading" type="Label" parent="."]
 visible = false
@@ -583,7 +450,7 @@ volume_db = -25.384
 [connection signal="pressed" from="Front/Play" to="." method="_on_PlayFront_pressed"]
 [connection signal="pressed" from="Front/Content" to="." method="_on_Content_pressed"]
 [connection signal="pressed" from="Front/Create" to="." method="_on_FrontCreate_pressed"]
-[connection signal="pressed" from="Front/Settings" to="." method="_on_SettingsFrong_pressed"]
+[connection signal="pressed" from="Front/Settings" to="." method="_on_SettingsFront_pressed"]
 [connection signal="pressed" from="Front/Quit" to="." method="_on_Quit_pressed"]
 [connection signal="item_selected" from="Play/Selection/Tracks/ItemList" to="." method="_on_ItemList_itemTracks_selected"]
 [connection signal="item_selected" from="Play/Selection/Scenarios/ItemList" to="." method="_on_ItemList_scenario_selected"]
@@ -592,12 +459,5 @@ volume_db = -25.384
 [connection signal="pressed" from="Play/Buttons/Play" to="." method="_on_PlayPlay_pressed"]
 [connection signal="pressed" from="Content/Buttons/Back" to="." method="_on_BackContent_pressed"]
 [connection signal="pressed" from="Content/Buttons/Reload" to="." method="_on_ReloadContent_pressed"]
-[connection signal="pressed" from="Settings/GridContainer/Fullscreen" to="." method="_on_FullscreenSettings_pressed"]
-[connection signal="pressed" from="Settings/GridContainer/MainMenuMusic" to="." method="_on_SettingsMainMenuMusic_pressed"]
-[connection signal="pressed" from="Settings/GridContainer/Shadows" to="." method="_on_SettingsShadows_pressed"]
-[connection signal="value_changed" from="Settings/GridContainer/ViewDistance" to="." method="_on_SettingsViewDistance_value_changed"]
-[connection signal="pressed" from="Settings/GridContainer/AntiAliasing" to="." method="_on_SettingsAntiAlasing_pressed"]
-[connection signal="pressed" from="Settings/GridContainer/Fog" to="." method="_on_SettingsFog_pressed"]
-[connection signal="pressed" from="Settings/Buttons/Back" to="." method="_on_BackSettings_pressed"]
 [connection signal="pressed" from="FeedBack/VBoxContainer/HBoxContainer/Later" to="." method="_on_Later_pressed"]
 [connection signal="pressed" from="FeedBack/VBoxContainer/HBoxContainer/OpenWebBrowser" to="." method="_on_OpenWebBrowser_pressed"]

--- a/src/addons/Libre_Train_Sim_Editor/Data/Modules/SettingsMenu.tscn
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Modules/SettingsMenu.tscn
@@ -1,0 +1,149 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Misc/FontMedium.tres" type="DynamicFont" id=1]
+[ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Scripts/SettingsMenu.gd" type="Script" id=2]
+
+[node name="Settings" type="VBoxContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 25.0
+margin_top = 13.0
+margin_right = -29.0
+margin_bottom = -24.0
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" type="Label" parent="."]
+margin_right = 970.0
+margin_bottom = 45.0
+custom_fonts/font = ExtResource( 1 )
+text = "Settings:"
+align = 1
+
+[node name="Control" type="Control" parent="."]
+margin_top = 49.0
+margin_right = 970.0
+margin_bottom = 192.0
+size_flags_vertical = 3
+
+[node name="GridContainer" type="GridContainer" parent="."]
+margin_left = 400.0
+margin_top = 196.0
+margin_right = 569.0
+margin_bottom = 360.0
+size_flags_horizontal = 4
+columns = 2
+
+[node name="Label" type="Label" parent="GridContainer"]
+margin_top = 5.0
+margin_right = 91.0
+margin_bottom = 19.0
+text = "Fullscreen"
+
+[node name="Fullscreen" type="CheckBox" parent="GridContainer"]
+margin_left = 120.0
+margin_right = 144.0
+margin_bottom = 24.0
+size_flags_horizontal = 4
+
+[node name="Label6" type="Label" parent="GridContainer"]
+margin_top = 33.0
+margin_right = 91.0
+margin_bottom = 47.0
+text = "Music"
+
+[node name="MainMenuMusic" type="CheckBox" parent="GridContainer"]
+margin_left = 120.0
+margin_top = 28.0
+margin_right = 144.0
+margin_bottom = 52.0
+size_flags_horizontal = 4
+
+[node name="Label2" type="Label" parent="GridContainer"]
+margin_top = 61.0
+margin_right = 91.0
+margin_bottom = 75.0
+text = "Shadows"
+
+[node name="Shadows" type="CheckBox" parent="GridContainer"]
+margin_left = 120.0
+margin_top = 56.0
+margin_right = 144.0
+margin_bottom = 80.0
+size_flags_horizontal = 4
+
+[node name="Label3" type="Label" parent="GridContainer"]
+margin_top = 89.0
+margin_right = 91.0
+margin_bottom = 103.0
+text = "View-Distance"
+
+[node name="ViewDistance" type="SpinBox" parent="GridContainer"]
+margin_left = 95.0
+margin_top = 84.0
+margin_right = 169.0
+margin_bottom = 108.0
+min_value = 250.0
+max_value = 1000.0
+value = 1000.0
+suffix = "m"
+
+[node name="Label4" type="Label" parent="GridContainer"]
+margin_top = 117.0
+margin_right = 91.0
+margin_bottom = 131.0
+text = "Anti Aliasing"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="AntiAliasing" type="CheckBox" parent="GridContainer"]
+margin_left = 120.0
+margin_top = 112.0
+margin_right = 144.0
+margin_bottom = 136.0
+size_flags_horizontal = 4
+
+[node name="Label5" type="Label" parent="GridContainer"]
+margin_top = 145.0
+margin_right = 91.0
+margin_bottom = 159.0
+text = "Fog"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Fog" type="CheckBox" parent="GridContainer"]
+margin_left = 120.0
+margin_top = 140.0
+margin_right = 144.0
+margin_bottom = 164.0
+size_flags_horizontal = 4
+
+[node name="Control2" type="Control" parent="."]
+margin_top = 364.0
+margin_right = 970.0
+margin_bottom = 508.0
+size_flags_vertical = 3
+
+[node name="Buttons" type="HBoxContainer" parent="."]
+margin_top = 512.0
+margin_right = 970.0
+margin_bottom = 563.0
+
+[node name="Back" type="Button" parent="Buttons"]
+margin_right = 970.0
+margin_bottom = 51.0
+rect_min_size = Vector2( 200, 0 )
+size_flags_horizontal = 3
+custom_fonts/font = ExtResource( 1 )
+text = "Back"
+[connection signal="pressed" from="GridContainer/Fullscreen" to="." method="_on_Fullscreen_pressed"]
+[connection signal="pressed" from="GridContainer/MainMenuMusic" to="." method="_on_MainMenuMusic_pressed"]
+[connection signal="pressed" from="GridContainer/Shadows" to="." method="_on_Shadows_pressed"]
+[connection signal="value_changed" from="GridContainer/ViewDistance" to="." method="_on_ViewDistance_value_changed"]
+[connection signal="pressed" from="GridContainer/AntiAliasing" to="." method="_on_AntiAliasing_pressed"]
+[connection signal="pressed" from="GridContainer/Fog" to="." method="_on_Fog_pressed"]
+[connection signal="pressed" from="Buttons/Back" to="." method="_on_Back_pressed"]

--- a/src/addons/Libre_Train_Sim_Editor/Data/Modules/SettingsMenu.tscn
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Modules/SettingsMenu.tscn
@@ -25,14 +25,14 @@ align = 1
 [node name="Control" type="Control" parent="."]
 margin_top = 49.0
 margin_right = 970.0
-margin_bottom = 192.0
+margin_bottom = 194.0
 size_flags_vertical = 3
 
 [node name="GridContainer" type="GridContainer" parent="."]
 margin_left = 400.0
-margin_top = 196.0
+margin_top = 198.0
 margin_right = 569.0
-margin_bottom = 360.0
+margin_bottom = 358.0
 size_flags_horizontal = 4
 columns = 2
 
@@ -91,25 +91,25 @@ value = 1000.0
 suffix = "m"
 
 [node name="Label4" type="Label" parent="GridContainer"]
-margin_top = 117.0
+margin_top = 115.0
 margin_right = 91.0
-margin_bottom = 131.0
+margin_bottom = 129.0
 text = "Anti Aliasing"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="AntiAliasing" type="CheckBox" parent="GridContainer"]
-margin_left = 120.0
+[node name="AntiAliasing" type="OptionButton" parent="GridContainer"]
+margin_left = 117.0
 margin_top = 112.0
-margin_right = 144.0
-margin_bottom = 136.0
+margin_right = 146.0
+margin_bottom = 132.0
 size_flags_horizontal = 4
 
 [node name="Label5" type="Label" parent="GridContainer"]
-margin_top = 145.0
+margin_top = 141.0
 margin_right = 91.0
-margin_bottom = 159.0
+margin_bottom = 155.0
 text = "Fog"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -117,13 +117,13 @@ __meta__ = {
 
 [node name="Fog" type="CheckBox" parent="GridContainer"]
 margin_left = 120.0
-margin_top = 140.0
+margin_top = 136.0
 margin_right = 144.0
-margin_bottom = 164.0
+margin_bottom = 160.0
 size_flags_horizontal = 4
 
 [node name="Control2" type="Control" parent="."]
-margin_top = 364.0
+margin_top = 362.0
 margin_right = 970.0
 margin_bottom = 508.0
 size_flags_vertical = 3
@@ -144,6 +144,6 @@ text = "Back"
 [connection signal="pressed" from="GridContainer/MainMenuMusic" to="." method="_on_MainMenuMusic_pressed"]
 [connection signal="pressed" from="GridContainer/Shadows" to="." method="_on_Shadows_pressed"]
 [connection signal="value_changed" from="GridContainer/ViewDistance" to="." method="_on_ViewDistance_value_changed"]
-[connection signal="pressed" from="GridContainer/AntiAliasing" to="." method="_on_AntiAliasing_pressed"]
+[connection signal="item_selected" from="GridContainer/AntiAliasing" to="." method="_on_AntiAliasing_item_selected"]
 [connection signal="pressed" from="GridContainer/Fog" to="." method="_on_Fog_pressed"]
 [connection signal="pressed" from="Buttons/Back" to="." method="_on_Back_pressed"]

--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/MainMenu.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/MainMenu.gd
@@ -78,15 +78,10 @@ func _on_Content_pressed():
 	$MenuBackground.show()
 	$Content.show()
 
-func _on_SettingsFrong_pressed():
+func _on_SettingsFront_pressed():
 	$Front.hide()
 	$MenuBackground.show()
 	$Settings.show()
-	update_settings()
-	pass # Replace with function body.
-	
-
-
 
 func update_config():
 	## Get All .pck files:
@@ -199,57 +194,6 @@ func _on_BackContent_pressed():
 func _on_ReloadContent_pressed():
 	update_config()
 	update_content()
-
-
-
-
-## Settings:
-func _on_FullscreenSettings_pressed():
-	config.set_value("Settings", "fullscreen", $Settings/GridContainer/Fullscreen.pressed)
-	config.save(save_path)
-	OS.window_fullscreen = $Settings/GridContainer/Fullscreen.pressed
-	
-func _on_SettingsShadows_pressed():
-	config.set_value("Settings", "shadows", $Settings/GridContainer/Shadows.pressed)
-	config.save(save_path)
-
-func _on_SettingsViewDistance_value_changed(value):
-	config.set_value("Settings", "viewDistance", $Settings/GridContainer/ViewDistance.value)
-	config.save(save_path)
-
-
-func _on_SettingsAntiAlasing_pressed():
-	config.set_value("Settings", "antiAliasing", $Settings/GridContainer/AntiAliasing.pressed)
-	config.save(save_path)
-
-func _on_SettingsFog_pressed():
-	config.set_value("Settings", "fog", $Settings/GridContainer/Fog.pressed)
-	config.save(save_path)
-
-func _on_SettingsMainMenuMusic_pressed():
-	config.set_value("Settings", "mainMenuMusic", $Settings/GridContainer/MainMenuMusic.pressed)
-	config.save(save_path)
-	update_MainMenuMusic()
-
-func update_settings():
-	$Settings/GridContainer/Fullscreen.pressed = config.get_value("Settings", "fullscreen", true)
-	$Settings/GridContainer/Shadows.pressed = config.get_value("Settings", "shadows", true)
-	$Settings/GridContainer/ViewDistance.value = config.get_value("Settings", "viewDistance", 1000)
-	$Settings/GridContainer/AntiAliasing.pressed = config.get_value("Settings", "antiAliasing", true)
-	$Settings/GridContainer/Fog.pressed = config.get_value("Settings", "fog", true)
-	$Settings/GridContainer/MainMenuMusic.pressed = config.get_value("Settings", "mainMenuMusic", true)
-
-	
-	
-
-
-func _on_BackSettings_pressed():
-	$Settings.hide()
-	$MenuBackground.hide()
-	$Front.show()
-	
-
-
 
 
 func _on_ItemList_scenario_selected(index):

--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/SettingsMenu.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/SettingsMenu.gd
@@ -1,0 +1,54 @@
+extends Control
+
+var save_path
+var config
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	save_path = get_parent().save_path
+	config = get_parent().config
+	$GridContainer/Fullscreen.pressed = config.get_value("Settings", "fullscreen", true)
+	$GridContainer/Shadows.pressed = config.get_value("Settings", "shadows", true)
+	$GridContainer/ViewDistance.value = config.get_value("Settings", "viewDistance", 1000)
+	$GridContainer/AntiAliasing.pressed = config.get_value("Settings", "antiAliasing", true)
+	$GridContainer/Fog.pressed = config.get_value("Settings", "fog", true)
+	$GridContainer/MainMenuMusic.pressed = config.get_value("Settings", "mainMenuMusic", true)
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+func _on_Fullscreen_pressed():
+	config.set_value("Settings", "fullscreen", $GridContainer/Fullscreen.pressed)
+	config.save(save_path)
+	OS.window_fullscreen = $GridContainer/Fullscreen.pressed
+	
+func _on_Shadows_pressed():
+	config.set_value("Settings", "shadows", $GridContainer/Shadows.pressed)
+	config.save(save_path)
+
+func _on_ViewDistance_value_changed(value):
+	config.set_value("Settings", "viewDistance", $GridContainer/ViewDistance.value)
+	config.save(save_path)
+
+func _on_AntiAliasing_pressed():
+	config.set_value("Settings", "antiAliasing", $GridContainer/AntiAliasing.pressed)
+	config.save(save_path)
+
+func _on_Fog_pressed():
+	config.set_value("Settings", "fog", $GridContainer/Fog.pressed)
+	config.save(save_path)
+
+func _on_MainMenuMusic_pressed():
+	config.set_value("Settings", "mainMenuMusic", $GridContainer/MainMenuMusic.pressed)
+	config.save(save_path)
+	get_parent().update_MainMenuMusic()
+
+func _on_Back_pressed():
+	hide()
+	get_node("../MenuBackground").hide()
+	get_node("../Front").show()
+	
+
+
+

--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/SettingsMenu.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/SettingsMenu.gd
@@ -7,12 +7,20 @@ var config
 func _ready():
 	save_path = get_parent().save_path
 	config = get_parent().config
+	
+	$GridContainer/AntiAliasing.add_item("Disabled", Viewport.MSAA_DISABLED)
+	$GridContainer/AntiAliasing.add_item("2x", Viewport.MSAA_2X)
+	$GridContainer/AntiAliasing.add_item("4x", Viewport.MSAA_4X)
+	$GridContainer/AntiAliasing.add_item("8x", Viewport.MSAA_8X)
+	$GridContainer/AntiAliasing.add_item("16x", Viewport.MSAA_16X)
+	$GridContainer/AntiAliasing.select(config.get_value("Settings", "antiAliasing", ProjectSettings.get_setting("rendering/quality/filters/msaa")))
+	
 	$GridContainer/Fullscreen.pressed = config.get_value("Settings", "fullscreen", true)
 	$GridContainer/Shadows.pressed = config.get_value("Settings", "shadows", true)
 	$GridContainer/ViewDistance.value = config.get_value("Settings", "viewDistance", 1000)
-	$GridContainer/AntiAliasing.pressed = config.get_value("Settings", "antiAliasing", true)
 	$GridContainer/Fog.pressed = config.get_value("Settings", "fog", true)
 	$GridContainer/MainMenuMusic.pressed = config.get_value("Settings", "mainMenuMusic", true)
+
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
@@ -31,8 +39,8 @@ func _on_ViewDistance_value_changed(value):
 	config.set_value("Settings", "viewDistance", $GridContainer/ViewDistance.value)
 	config.save(save_path)
 
-func _on_AntiAliasing_pressed():
-	config.set_value("Settings", "antiAliasing", $GridContainer/AntiAliasing.pressed)
+func _on_AntiAliasing_item_selected(index):
+	config.set_value("Settings", "antiAliasing", $GridContainer/AntiAliasing.selected)
 	config.save(save_path)
 
 func _on_Fog_pressed():

--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/World.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/World.gd
@@ -78,10 +78,7 @@ func apply_user_settings():
 	if get_node("DirectionalLight") != null:
 		$DirectionalLight.shadow_enabled = userConfig.get_value("Settings", "shadows", true)
 	player.get_node("Camera").far = userConfig.get_value("Settings", "viewDistance", 1000)
-	if userConfig.get_value("Settings", "antiAliasing", true):
-		ProjectSettings.set_setting("rendering/quality/filters/msaa", 4)
-	else: 
-		ProjectSettings.set_setting("rendering/quality/filters/msaa", 0)
+	get_viewport().set_msaa(userConfig.get_value("Settings", "antiAliasing", ProjectSettings.get_setting("rendering/quality/filters/msaa")))
 	$WorldEnvironment.environment.fog_enabled = userConfig.get_value("Settings", "fog", true)
 	
 func _process(delta):


### PR DESCRIPTION
- makes it easier to work on settings layout
- also gd script extracted and main menu reduced in scope
- now settings scene is an instance node of main menu

Started with settings because I plan to add more knobs in there and having a simple script and easy to change scene (no need to change visibilities in main menu).
If you like the idea, I'd do the same for all sub-menus