### PR TITLE
bake_route fixes

### DIFF
--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/Math.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/Math.gd
@@ -44,7 +44,7 @@ func kmHToSpeed(speed):
 func normDeg(degree):
 	while degree > 180.0:
 		degree -= 360.0
-	while degree < 180.0:
+	while degree < -180.0:
 		degree += 360.0
 	return degree
 	

--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/Math.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/Math.gd
@@ -47,7 +47,18 @@ func normDeg(degree):
 	while degree < -180.0:
 		degree += 360.0
 	return degree
-	
+
+# returns the distance in degrees between the 2 rotations, also in degrees
+# the SMALLER of the 2 possible angles is chosen!
+# examples:
+# angle_dist_deg(45, -45) = 90
+# angle_dist_deg(-45, 45) = 90
+# angle_dist_deg(0, 170) = 170
+# angle_dist_deg(0, 190) = 170
+func angle_distance_deg(rot1, rot2) -> float:
+	var normed1 = normDeg(rot1)
+	var normed2 = normDeg(rot2)
+	return abs(normDeg(normed1 - normed2))
 
 #func sort_signals(signalTable, forward = true):
 #	var signalT = [signalTable.values(), signalTable.keys()]

--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/Player.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/Player.gd
@@ -969,9 +969,9 @@ func bake_route(): ## Generate the whole route for the train.
 	while(true): ## Find next Rail
 		var possibleRails = []
 		for rail in world.get_node("Rails").get_children(): ## Get Rails, which are in the near of the endposition of current rail:
-			if currentpos.distance_to(rail.startpos) < 0.1 and abs(Math.normDeg(currentrot) - abs(Math.normDeg(rail.startrot))) < 1 and rail.name != currentR.name:
+			if rail.name != currentR.name and currentpos.distance_to(rail.startpos) < 0.1 and Math.angle_distance_deg(currentrot, rail.startrot) < 1:
 				possibleRails.append(rail.name)
-			elif currentpos.distance_to(rail.endpos) < 0.1 and abs(Math.normDeg(currentrot) - abs(Math.normDeg(rail.endrot+180.0))) < 1 and rail.name != currentR.name:
+			elif rail.name != currentR.name and currentpos.distance_to(rail.endpos) < 0.1 and Math.angle_distance_deg(currentrot, rail.endrot+180) < 1:
 				possibleRails.append(rail.name)
 		
 		if possibleRails.size() == 0: ## If no Rail was found


### PR DESCRIPTION
Sometimes, `bake_route()` would not detect rails that should be connected. 
Example: 
```gdscript
currentrot = -180
rail.startrot = 179.999985
Math.normDeg(currentrot) = 180
Math.normDeg(rail.startrot) = 539.999985
abs(Math.normDeg(currentrot) - abs(Math.normDeg(rail.startrot))): 359.999985
```
The expected distance is `0.000015`, because 180 and -180 are infact the same angle. But this was handled incorrectly.
