### PR TITLE
fix: Signal VisualInstance wrong initial state

### DIFF
--- a/src/Resources/Basic/SignalTypes/Default/ScriptingDefault.gd
+++ b/src/Resources/Basic/SignalTypes/Default/ScriptingDefault.gd
@@ -21,6 +21,8 @@ func _ready():
 	texture = $Viewport2.get_texture()
 	$Screen2.material_override = $Screen2.material_override.duplicate(true)
 	$Screen2.material_override.emission_texture = texture
+	
+	update_status(signal_logic)
 
 
 func blink():


### PR DESCRIPTION
The VisualInstance will show the wrong state, when a non-default state is set for the signal at spawn time. 

Eg. Signal status is set to green in the Scene file, but the VisualInstance will be red.