### PR TITLE
Enforce LF in repo and tell GH about GDScript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.gd linguist-language=gdscript
+* text=auto eol=lf


### PR DESCRIPTION
We should enforce line endings to be lf everywhere (even if I am the only person, who pushes CRLF line endings...).

GitHub detects some GDScript as GAP (whatever that is)... Let's try to force it otherwise