### PR TITLE
Improve editor camera

### DIFF
--- a/src/addons/Libre_Train_Sim_Editor/Data/Modules/Editor.tscn
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Modules/Editor.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=13 format=2]
 
-[ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Modules/FreeCamera.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Scripts/editor_camera.gd" type="Script" id=1]
 [ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Scripts/Editor.gd" type="Script" id=2]
 [ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Editor/RailLogic.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/Libre_Train_Sim_Editor/Data/Misc/FontMedium.tres" type="DynamicFont" id=5]
@@ -15,8 +15,6 @@
 
 [node name="Editor" type="Spatial"]
 script = ExtResource( 2 )
-
-[node name="FreeCamera" parent="." instance=ExtResource( 1 )]
 
 [node name="EditorHUD" type="CanvasLayer" parent="."]
 pause_mode = 2
@@ -541,7 +539,11 @@ __meta__ = {
 
 [node name="Landscape" type="Spatial" parent="."]
 
-[connection signal="single_rightclick" from="FreeCamera" to="." method="_on_FreeCamera_single_rightclick"]
+[node name="Camera" type="Camera" parent="."]
+current = true
+far = 1000.0
+script = ExtResource( 1 )
+
 [connection signal="mouse_entered" from="EditorHUD/ShowSettingsButton" to="EditorHUD" method="_on_Mouse_entered_UI"]
 [connection signal="mouse_exited" from="EditorHUD/ShowSettingsButton" to="EditorHUD" method="_on_Mouse_exited_UI"]
 [connection signal="pressed" from="EditorHUD/ShowSettingsButton" to="EditorHUD" method="_on_ShowSettings_pressed"]

--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/Editor.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/Editor.gd
@@ -1,6 +1,6 @@
 extends Spatial
 
-onready var camera = get_node("FreeCamera")
+onready var camera = $Camera
 var editor_directory = ""
 
 var selected_object = null
@@ -145,7 +145,7 @@ func load_world():
 	## Load Camera Position
 	var last_editor_camera_transforms = jSaveManager.get_value("last_editor_camera_transforms", {})
 	if last_editor_camera_transforms.has(Root.current_editor_track):
-		$FreeCamera.transform = last_editor_camera_transforms[Root.current_editor_track]
+		camera.transform = last_editor_camera_transforms[Root.current_editor_track]
 
 	## Add Colliding Boxes to Buildings:
 	for building in $World/Buildings.get_children():
@@ -163,7 +163,7 @@ func load_world():
 func save_world():
 	## Save Camera Position
 	var last_editor_camera_transforms = jSaveManager.get_value("last_editor_camera_transforms", {})
-	last_editor_camera_transforms[Root.current_editor_track] = $FreeCamera.transform
+	last_editor_camera_transforms[Root.current_editor_track] = camera.transform
 	jSaveManager.save_value("last_editor_camera_transforms", last_editor_camera_transforms)
 
 	$World.unload_and_save_all_chunks()
@@ -239,7 +239,7 @@ func add_rail():
 	set_selected_object(rail_instance)
 
 func get_current_ground_position() -> Vector3:
-	var position = $FreeCamera.translation
+	var position = camera.translation
 	position.y = $World.get_terrain_height_at(Vector2(position.x, position.z))
 	return position
 
@@ -256,11 +256,6 @@ func add_object(complete_path : String):
 	mesh_instance.add_child(preload("res://addons/Libre_Train_Sim_Editor/Data/Modules/SelectCollider.tscn").instance())
 	set_selected_object(mesh_instance)
 
-
-
-func _on_FreeCamera_single_rightclick():
-	if not $EditorHUD.mouse_over_ui:
-		clear_selected_object()
 
 func test_track_pck():
 	save_world()
@@ -491,8 +486,8 @@ func jump_to_station(station_node_name):
 	var station_node = $World/Signals.get_node(station_node_name)
 	if station_node == null:
 		print_debug("Station not found:" + station_node_name)
-	$FreeCamera.transform = station_node.transform.translated(Vector3(0, 5, 0))
-	$FreeCamera.rotation_degrees.y -= 90
+	camera.transform = station_node.transform.translated(Vector3(0, 5, 0))
+	camera.rotation_degrees.y -= 90
 
 
 var all_chunks = []
@@ -515,7 +510,7 @@ func generate_grass_panes():
 
 var ist_chunks = []
 func load_chunks_near_camera():
-	var wanted_chunks = $World.get_chunks_around_position($FreeCamera.translation)
+	var wanted_chunks = $World.get_chunks_around_position(camera.translation)
 	for wanted_chunk in wanted_chunks.duplicate():
 		if ist_chunks.has(wanted_chunk):
 			wanted_chunks.erase(wanted_chunk)

--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/camera_base.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/camera_base.gd
@@ -1,0 +1,82 @@
+class_name CameraBase
+extends Camera
+
+
+var rot := Vector2.ZERO # is in screen coordinates
+var capture_mouse_position := Vector2.ZERO
+
+var zoom_level: float = 80
+var orbit_rotation_helper := Spatial.new()
+
+
+func _prepare_orbit() -> void:
+	assert(get_parent() != orbit_rotation_helper)
+	get_parent().add_child(orbit_rotation_helper)
+	var target_point := Plane.PLANE_XZ.intersects_ray(\
+			global_transform.origin, project_ray_normal(get_viewport().size/2))
+	if target_point == null:
+		# Set point with zoom_level distance in direction of camera
+		target_point = project_position(get_viewport().size/2, zoom_level)
+	var old_transform = global_transform
+	get_parent().remove_child(self)
+	orbit_rotation_helper.global_transform.origin = target_point
+	orbit_rotation_helper.global_transform.basis = old_transform.basis
+	orbit_rotation_helper.add_child(self)
+	global_transform = old_transform
+
+
+func _remove_orbit() -> void:
+	assert(get_parent() == orbit_rotation_helper)
+	var old_transform = global_transform
+	orbit_rotation_helper.remove_child(self)
+	orbit_rotation_helper.get_parent().add_child(self)
+	get_parent().remove_child(orbit_rotation_helper)
+	global_transform = old_transform
+
+
+func _zoom(offset: float) -> void:
+	var prev_zoom_level := zoom_level
+	zoom_level = clamp(zoom_level - offset, 0.2, 250)
+	translate(Vector3(0,0, prev_zoom_level - zoom_level))
+
+
+func _rotate_local(offset: Vector2) -> void:
+	rot -= offset
+	# Prevent the world being upside down
+	rot.y = clamp(rot.y, -0.5*PI, 0.5*PI)
+	transform.basis = Basis()
+	rotate_object_local(Vector3.UP, rot.x)
+	rotate_object_local(Vector3.RIGHT, rot.y)
+
+
+func _rotate_orbit(offset: Vector2) -> void:
+		if get_parent() != orbit_rotation_helper:
+			_prepare_orbit()
+		rot -= offset
+		# Prevent the world being upside down
+		rot.y = clamp(rot.y, -0.5*PI, 0.5*PI)
+		orbit_rotation_helper.transform.basis = Basis()
+		orbit_rotation_helper.rotate_object_local(Vector3.UP, rot.x)
+		orbit_rotation_helper.rotate_object_local(Vector3.RIGHT, rot.y)
+
+
+func _pan_local(offset: Vector2) -> void:
+	translate(Vector3(-offset.x, offset.y, 0))
+
+
+func _pan_global(offset: Vector2) -> void:
+	transform.basis = Basis()
+	rotate_object_local(Vector3.UP, rot.x)
+	translate(Vector3(-offset.x, 0, \
+		-offset.y))
+	rotate_object_local(Vector3.RIGHT, rot.y)
+
+
+func _capture_mouse():
+	capture_mouse_position = get_viewport().get_mouse_position()
+	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+
+
+func _free_mouse():
+	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+	get_viewport().warp_mouse(capture_mouse_position)

--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/editor_camera.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/editor_camera.gd
@@ -1,0 +1,71 @@
+class_name EditorCamera
+extends CameraBase
+
+
+export var mouse_sensitivity: float = 0.003
+export var normal_speed: float = 1
+export var fast_speed: float = 3
+export var pan_move_sensitivity: float = 0.25
+
+
+var velocity := Vector3.ZERO
+var is_moving_first_person := false
+var is_panning := false
+
+
+# TODO: F to focus on selected object
+# TODO: Fix Pan speed depending on distance to ground or zoom
+#	needs object picking
+func _unhandled_input(event: InputEvent) -> void:
+	var mm := event as InputEventMouseMotion
+	if mm != null and is_moving_first_person:
+		_rotate_local(mm.relative * mouse_sensitivity)
+	elif mm != null and is_panning:
+		if get_parent() == orbit_rotation_helper and (mm.shift || mm.alt || mm.control):
+			_remove_orbit()
+		if mm.alt:
+			_pan_local(mm.relative * pan_move_sensitivity)
+		elif mm.shift:
+			_pan_global(mm.relative * pan_move_sensitivity)
+		elif mm.control:
+			_zoom(-mm.relative.y * pan_move_sensitivity)
+		else:
+			_rotate_orbit(mm.relative * mouse_sensitivity)
+
+	var mb := event as InputEventMouseButton
+	if mb != null and mb.button_index == BUTTON_RIGHT:
+		if mb.pressed and !is_moving_first_person:
+			_capture_mouse()
+		elif !mb.pressed and is_moving_first_person:
+			_free_mouse()
+		is_moving_first_person = mb.pressed
+	elif mb != null and mb.button_index == BUTTON_MIDDLE:
+		if mb.pressed and !is_panning:
+			_capture_mouse()
+			if mb.shift:
+				_prepare_orbit()
+		elif !mb.pressed and is_panning:
+			_free_mouse()
+			if get_parent() == orbit_rotation_helper:
+				_remove_orbit()
+		is_panning = mb.pressed
+	elif mb != null and mb.button_index == BUTTON_WHEEL_DOWN:
+		_zoom(10 * max(mb.factor, 1))
+	elif mb != null and mb.button_index == BUTTON_WHEEL_UP:
+		_zoom(-10 * max(mb.factor, 1))
+
+
+func _physics_process(_delta: float) -> void:
+	if !is_moving_first_person:
+		return
+	var direction = Vector3(\
+		Input.get_action_strength("right") - Input.get_action_strength("left"), \
+		Input.get_action_strength("up") - Input.get_action_strength("down"), \
+		Input.get_action_strength("backward") - Input.get_action_strength("forward")\
+		).normalized()
+
+	direction *= fast_speed if Input.is_action_pressed("shift") else normal_speed
+	direction = lerp(velocity, direction, 0.3)
+	velocity = direction
+	translate_object_local(direction)
+

--- a/src/project.godot
+++ b/src/project.godot
@@ -19,10 +19,20 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/Libre_Train_Sim_Editor/Data/Misc/AutoDynamicFont.gd"
 }, {
+"base": "Camera",
+"class": "CameraBase",
+"language": "GDScript",
+"path": "res://addons/Libre_Train_Sim_Editor/Data/Scripts/camera_base.gd"
+}, {
 "base": "ItemList",
 "class": "ColoredItemList",
 "language": "GDScript",
 "path": "res://addons/Libre_Train_Sim_Editor/Data/Modules/UI/colored_item_list.gd"
+}, {
+"base": "CameraBase",
+"class": "EditorCamera",
+"language": "GDScript",
+"path": "res://addons/Libre_Train_Sim_Editor/Data/Scripts/editor_camera.gd"
 }, {
 "base": "Label",
 "class": "InputLabel",
@@ -67,7 +77,9 @@ _global_script_classes=[ {
 _global_script_class_icons={
 "Authors": "",
 "AutoDynamicFont": "",
+"CameraBase": "",
 "ColoredItemList": "",
+"EditorCamera": "",
 "InputLabel": "",
 "Map": "",
 "Pause": "",
@@ -346,6 +358,41 @@ reverser-={
 fullscreen={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":true,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"unicode":0,"echo":false,"script":null)
+ ]
+}
+forward={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
+ ]
+}
+backward={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
+ ]
+}
+up={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":69,"unicode":0,"echo":false,"script":null)
+ ]
+}
+down={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":81,"unicode":0,"echo":false,"script":null)
+ ]
+}
+left={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
+ ]
+}
+right={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
+ ]
+}
+shift={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777237,"unicode":0,"echo":false,"script":null)
  ]
 }
 


### PR DESCRIPTION
This PR improves the editor camera a lot.

When pressing `RMB`, you can fly the camera like in a FP game. Use `W` (forward), `A` (left), `S` (back), `D` (right), `E` (up), `Q` (down) and `Shift` (quick).
When pressing `MMB`, you can pan the camera on the xz-Plane.
When pressing `Shift+MMB`, you can rotate the camera around the ground (should be refactored in the future to enable objects) or around a point in the distance of the `zoom_level`.
When pressing `Ctrl+MMB` or using the scroll wheel, you can zoom. Please note, it is rather a movement on the forward axis rather than a real zoom.
When pressing `Alt+MMB`, you can pan the camera on its local xy-Plane.

Fixes #165 