### PR TITLE
Fix select collider not working with signals

### DIFF
--- a/src/addons/Libre_Train_Sim_Editor/Data/Scripts/Signal.gd
+++ b/src/addons/Libre_Train_Sim_Editor/Data/Scripts/Signal.gd
@@ -1,4 +1,3 @@
-tool
 extends Spatial
 const type = "Signal" # Never change this type!!
 onready var world = find_parent("World")
@@ -100,6 +99,8 @@ func _ready():
 
 	if get_node_or_null("VisualInstance") != null:
 		connect_visual_instance()
+	else:
+		create_visual_instance()
 
 	# Set Signal while adding to the Signals node
 	if Engine.is_editor_hint() and not get_parent().name == "Signals":


### PR DESCRIPTION
It is not the select collider who is the problem, but the signal that creates the visual instance not in `_ready`. It will be create eventually through a series of calls started by the timer.

The select collider itself is not a beautiful either and should be reworked, but for now it works again.

Fixes #179