### PR TITLE
Add Highlight postprocessing to Editor selection (remove bouncing animation)

### DIFF
--- a/src/Data/Postprocess/HighlightPP.tscn
+++ b/src/Data/Postprocess/HighlightPP.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://Data/Postprocess/highlight_shader.gdshader" type="Shader" id=1]
+[ext_resource path="res://Data/Postprocess/ShaderPP.gd" type="Script" id=2]
+
+[sub_resource type="ShaderMaterial" id=1]
+shader = ExtResource( 1 )
+shader_param/highlight_color = Color( 1, 0.913725, 0, 0.231373 )
+
+[node name="HighlightPP" type="Node"]
+script = ExtResource( 2 )
+
+[node name="HighlightShader" type="ViewportContainer" parent="."]
+material = SubResource( 1 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+stretch = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Viewport" type="Viewport" parent="HighlightShader"]
+size = Vector2( 800, 600 )
+transparent_bg = true
+handle_input_locally = false
+keep_3d_linear = true
+debug_draw = 1
+render_target_update_mode = 3
+
+[node name="Camera" type="Camera" parent="HighlightShader/Viewport"]
+cull_mask = 2
+far = 1000.0

--- a/src/Data/Postprocess/LaplaceEdgeDetect.gdshader
+++ b/src/Data/Postprocess/LaplaceEdgeDetect.gdshader
@@ -1,0 +1,25 @@
+shader_type canvas_item;
+
+uniform vec4 highlight_color: hint_color = vec4(1.0, 0.0, 0.0, 1.0);
+
+void fragment() {
+	vec4 laplace;
+	
+	// laplace edge detection (faster to calc than sobel!)
+	laplace  =  8.0 * texture(TEXTURE, UV);
+	laplace += -1.0 * texture(TEXTURE, UV + vec2(-SCREEN_PIXEL_SIZE.x, -SCREEN_PIXEL_SIZE.y));
+	laplace += -1.0 * texture(TEXTURE, UV + vec2(-SCREEN_PIXEL_SIZE.x, SCREEN_PIXEL_SIZE.y));
+	laplace += -1.0 * texture(TEXTURE, UV + vec2(SCREEN_PIXEL_SIZE.x, -SCREEN_PIXEL_SIZE.y));
+	laplace += -1.0 * texture(TEXTURE, UV + vec2(SCREEN_PIXEL_SIZE.x, SCREEN_PIXEL_SIZE.y));
+	laplace += -1.0 * texture(TEXTURE, UV + vec2(SCREEN_PIXEL_SIZE.x, 0.0));
+	laplace += -1.0 * texture(TEXTURE, UV + vec2(-SCREEN_PIXEL_SIZE.x, 0.0));
+	laplace += -1.0 * texture(TEXTURE, UV + vec2(0.0, SCREEN_PIXEL_SIZE.y));
+	laplace += -1.0 * texture(TEXTURE, UV + vec2(0.0, -SCREEN_PIXEL_SIZE.y));
+	
+	
+	if(abs(laplace.x) < 0.001) {  // == 0
+		discard;
+	} else {
+		COLOR = highlight_color;
+	}
+}

--- a/src/Data/Postprocess/MaximumShader.gdshader
+++ b/src/Data/Postprocess/MaximumShader.gdshader
@@ -1,0 +1,26 @@
+shader_type canvas_item;
+
+// converts the texture to a binary texture
+// which means only black or white, depending on if a pixel contains information
+// or not.
+float tex_bin(sampler2D tex, vec2 uv) {
+	vec3 rgb = texture(tex, uv).xyz;
+	if(rgb == vec3(0)) {
+		return 0.0;
+	} else {
+		return 1.0;
+	}
+}
+
+void fragment() {
+	float col = tex_bin(TEXTURE, UV);
+	col = max(col, tex_bin(TEXTURE, UV + vec2(0.0, SCREEN_PIXEL_SIZE.y)));
+	col = max(col, tex_bin(TEXTURE, UV + vec2(0.0, -SCREEN_PIXEL_SIZE.y)));
+	col = max(col, tex_bin(TEXTURE, UV + vec2(SCREEN_PIXEL_SIZE.x, 0.0)));
+	col = max(col, tex_bin(TEXTURE, UV + vec2(-SCREEN_PIXEL_SIZE.x, 0.0)));
+	col = max(col, tex_bin(TEXTURE, UV + SCREEN_PIXEL_SIZE.xy));
+	col = max(col, tex_bin(TEXTURE, UV - SCREEN_PIXEL_SIZE.xy));
+	col = max(col, tex_bin(TEXTURE, UV + vec2(-SCREEN_PIXEL_SIZE.x, SCREEN_PIXEL_SIZE.y)));
+	col = max(col, tex_bin(TEXTURE, UV + vec2(SCREEN_PIXEL_SIZE.x, -SCREEN_PIXEL_SIZE.y)));
+	COLOR = vec4(col);
+}

--- a/src/Data/Postprocess/OutlinesPP.tscn
+++ b/src/Data/Postprocess/OutlinesPP.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://Data/Postprocess/MaximumShader.gdshader" type="Shader" id=1]
+[ext_resource path="res://Data/Postprocess/LaplaceEdgeDetect.gdshader" type="Shader" id=2]
+[ext_resource path="res://Data/Postprocess/ShaderPP.gd" type="Script" id=3]
+
+[sub_resource type="ShaderMaterial" id=1]
+shader = ExtResource( 2 )
+shader_param/highlight_color = Color( 1, 0, 0, 1 )
+
+[sub_resource type="ShaderMaterial" id=2]
+shader = ExtResource( 1 )
+
+[node name="OutlinesPP" type="Node"]
+script = ExtResource( 3 )
+
+[node name="EdgeDetectionPP" type="ViewportContainer" parent="."]
+material = SubResource( 1 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+stretch = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Viewport" type="Viewport" parent="EdgeDetectionPP"]
+size = Vector2( 800, 600 )
+transparent_bg = true
+handle_input_locally = false
+keep_3d_linear = true
+debug_draw = 1
+render_target_update_mode = 3
+
+[node name="MaximumFilterPP" type="ViewportContainer" parent="EdgeDetectionPP/Viewport"]
+material = SubResource( 2 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+mouse_filter = 2
+stretch = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Viewport" type="Viewport" parent="EdgeDetectionPP/Viewport/MaximumFilterPP"]
+size = Vector2( 800, 600 )
+transparent_bg = true
+handle_input_locally = false
+keep_3d_linear = true
+debug_draw = 1
+render_target_update_mode = 3
+
+[node name="Camera" type="Camera" parent="EdgeDetectionPP/Viewport/MaximumFilterPP/Viewport"]
+cull_mask = 2
+far = 1000.0

--- a/src/Data/Postprocess/ShaderPP.gd
+++ b/src/Data/Postprocess/ShaderPP.gd
@@ -1,0 +1,31 @@
+extends Node
+
+# README:
+# shaders are processed bottom-up
+# this means the most nested Viewport is run FIRST!
+
+# the camera node inside the viewport is necessary, because
+# it will only render Layer 2 (default is Layer 1)
+# so you have to put anything you want to be highlighted into Layer 2
+# like this: visual_instance.set_layer_mask_bit(1, true)
+# to remove the object from Layer 2:
+# visual_instance.set_layer_mask_bit(1, false)
+
+# Viewport is basically the Image we want to process
+# the ViewportContainer is the shader that processes that image
+# the ViewportContainer also has the side effect of then drawing that
+# processed image on top of the screen... :)
+
+# check ViewportContainer -> Material for the Shader
+
+export var highlight_color: Color
+
+onready var external_camera := get_viewport().get_camera()
+onready var shader_camera := find_node("Camera") as Camera
+
+func _ready():
+	get_child(0).material.set_shader_param("highlight_color", highlight_color)
+
+
+func _process(_delta: float) -> void:
+	shader_camera.global_transform = external_camera.global_transform

--- a/src/Data/Postprocess/highlight_shader.gdshader
+++ b/src/Data/Postprocess/highlight_shader.gdshader
@@ -1,0 +1,23 @@
+shader_type canvas_item;
+
+uniform vec4 highlight_color: hint_color = vec4(1.0, 0.0, 0.0, 0.25);
+
+// converts the texture to a binary texture
+// which means only black or white, depending on if a pixel contains information
+// or not. 
+int tex_bin(sampler2D tex, vec2 uv) {
+	vec3 rgb = texture(tex, uv).xyz;
+	if((rgb) == vec3(0)) {
+		return 0;
+	} else {
+		return 1;
+	}
+}
+
+void fragment() {
+	if (tex_bin(TEXTURE, UV) == 0) {
+		discard;
+	} else {
+		COLOR = highlight_color;
+	}
+}

--- a/src/Editor/Editor.tscn
+++ b/src/Editor/Editor.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://Editor/Scripts/editor_camera.gd" type="Script" id=1]
 [ext_resource path="res://Editor/Scripts/Editor.gd" type="Script" id=2]
 [ext_resource path="res://Editor/Modules/RailLogic.tscn" type="PackedScene" id=3]
+[ext_resource path="res://Data/Postprocess/OutlinesPP.tscn" type="PackedScene" id=4]
 [ext_resource path="res://Data/Fonts/FontMedium.tres" type="DynamicFont" id=5]
 [ext_resource path="res://Editor/Docks/RailBuilder/RailBuilder.tscn" type="PackedScene" id=6]
 [ext_resource path="res://Editor/Docks/RailAttachments/RailAttachments.tscn" type="PackedScene" id=7]
@@ -559,6 +560,9 @@ __meta__ = {
 current = true
 far = 1000.0
 script = ExtResource( 1 )
+
+[node name="OutlinesPP" parent="." instance=ExtResource( 4 )]
+highlight_color = Color( 1, 1, 0, 1 )
 
 [connection signal="pressed" from="EditorHUD/ShowSettingsButton" to="EditorHUD" method="_on_ShowSettings_pressed"]
 [connection signal="pressed" from="EditorHUD/SaveWorldButton" to="." method="_on_SaveWorldButton_pressed"]


### PR DESCRIPTION
This removes the "bouncing" animation from the selected object in Editor, and replaces it with Postprocessing Effects to outline and highlight the object.

This is what it would currently look like:
![image](https://user-images.githubusercontent.com/3923406/139576736-3afc757a-d5fb-4091-9948-22ee2f4ac404.png)

Of course, we can decide to only use outlines, or only use highlighting (they are 2 separate nodes that added to the Editor scene tree), and the colors are also configurable.

What is currently not configurable, though I'm sure I can work out how to do that, is the thickness of the outline, which is currently only about 2 pixels...