### PR TITLE
Fix chunk manager at loading far away from world origin

### DIFF
--- a/src/Data/Scripts/World.gd
+++ b/src/Data/Scripts/World.gd
@@ -13,6 +13,8 @@ var currentScenario := ""
 export (String) var FileName := "Name Me!"
 onready var trackName: String = FileName.rsplit("/")[0]
 
+export var world_origin_on_last_save = Vector3(0,0,0) # Used for chunk manager.
+
 var author: String = ""
 var picturePath: String = "res://screenshot.png"
 var description: String = ""
@@ -49,6 +51,7 @@ func _ready() -> void:
 	chunk_manager = ChunkManager.new()
 	chunk_manager.world = self
 	chunk_manager.name = "ChunkManager"
+	chunk_manager.world_origin = world_origin_on_last_save
 	add_child(chunk_manager)
 
 	# backward compat

--- a/src/Data/Scripts/chunk_manager.gd
+++ b/src/Data/Scripts/chunk_manager.gd
@@ -183,6 +183,9 @@ func _save_chunk(chunk_pos: Vector3):
 
 	_jsavemodule.save_value(chunk_to_string(chunk_pos), null)
 	_jsavemodule.save_value(chunk_to_string(chunk_pos), chunk)
+
+	world.world_origin_on_last_save = world_origin
+
 	Logger.log("Saved Chunk " + chunk_to_string(chunk_pos))
 
 


### PR DESCRIPTION
It makes sense to store this value in .tscn because all rail positions are moved too in the .tscn file.