### PR TITLE
Fix wrong launch language

### DIFF
--- a/src/Data/UI/main_menu.gd
+++ b/src/Data/UI/main_menu.gd
@@ -5,6 +5,9 @@ export var version = ""
 
 
 func _ready():
+	# Update GUI language directly at launch
+	jSettings.update_and_prepare_language_handling()
+
 	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 
 	$Version.text = "Version: %s" % version


### PR DESCRIPTION
Without this, the GUI is in the system language at launch, ignoring the user's saved choice.
With this fix, the user selected language (from the setting menu) is loaded directly at launch.

Fixes #350.