### PR TITLE
Make text_box use the new theme

### DIFF
--- a/src/Data/UI/text_box.gd
+++ b/src/Data/UI/text_box.gd
@@ -18,7 +18,7 @@ func message(text: String) -> void:
 	$MarginContainer/VBoxContainer/Message.text = text
 	visible = true
 	get_tree().paused = true
-	$MarginContainer/VBoxContainer/Ok.grab_focus()
+	$MarginContainer/VBoxContainer/Ok.grab_click_focus()
 
 
 func _on_Ok_pressed():

--- a/src/Data/UI/text_box.tscn
+++ b/src/Data/UI/text_box.tscn
@@ -1,18 +1,12 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://Data/Fonts/message_font.tres" type="DynamicFont" id=1]
 [ext_resource path="res://Data/Fonts/button_font.tres" type="DynamicFont" id=2]
-[ext_resource path="res://Resources/Textures/text_box.png" type="Texture" id=3]
+[ext_resource path="res://Data/UI/styles/panel_background.tres" type="StyleBox" id=3]
 [ext_resource path="res://Data/UI/text_box.gd" type="Script" id=4]
 [ext_resource path="res://Data/UI/translated_rich_rext_label.gd" type="Script" id=5]
-
-[sub_resource type="StyleBoxTexture" id=1]
-texture = ExtResource( 3 )
-region_rect = Rect2( 26, 26, 889, 543 )
-margin_left = 6.57943
-margin_right = 19.4478
-margin_top = 6.29013
-margin_bottom = 19.282
+[ext_resource path="res://Data/UI/styles/button_both.tres" type="Theme" id=6]
+[ext_resource path="res://Data/UI/styles/complete_menu.tres" type="Theme" id=7]
 
 [node name="TextBox" type="PanelContainer"]
 anchor_left = 0.5
@@ -23,17 +17,15 @@ margin_left = -348.0
 margin_top = -249.0
 margin_right = 361.0
 margin_bottom = 266.0
-custom_styles/panel = SubResource( 1 )
+theme = ExtResource( 7 )
+custom_styles/panel = ExtResource( 3 )
 script = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
-margin_left = 6.57943
-margin_top = 6.29013
-margin_right = 689.552
-margin_bottom = 495.718
+margin_left = 6.0
+margin_top = 10.0
+margin_right = 703.0
+margin_bottom = 511.0
 custom_constants/margin_right = 8
 custom_constants/margin_top = 8
 custom_constants/margin_left = 8
@@ -42,12 +34,12 @@ custom_constants/margin_bottom = 8
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
 margin_left = 8.0
 margin_top = 8.0
-margin_right = 674.0
-margin_bottom = 481.0
+margin_right = 689.0
+margin_bottom = 493.0
 
 [node name="Message" type="RichTextLabel" parent="MarginContainer/VBoxContainer"]
-margin_right = 666.0
-margin_bottom = 433.0
+margin_right = 681.0
+margin_bottom = 445.0
 focus_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -60,12 +52,13 @@ __meta__ = {
 }
 
 [node name="Ok" type="Button" parent="MarginContainer/VBoxContainer"]
-margin_top = 437.0
-margin_right = 666.0
-margin_bottom = 473.0
+margin_top = 449.0
+margin_right = 681.0
+margin_bottom = 485.0
 grow_horizontal = 2
 grow_vertical = 0
 rect_min_size = Vector2( 100, 36 )
+theme = ExtResource( 6 )
 custom_fonts/font = ExtResource( 2 )
 text = "OK"
 __meta__ = {

--- a/src/authors.tres
+++ b/src/authors.tres
@@ -5,5 +5,5 @@
 [resource]
 script = ExtResource( 1 )
 developers = [ "Jean3219 - Jean28518", "Johannes Witt - HaSa1002", "Dominik Waurenschk - DasCapschen" ]
-contributors = [ "librebob", "Bohdan Matviiv - bodamat", "Michele Comignano - comick", "Matthew - skyace65", "Yann Dirson - ydirson", "IntinteDAO", "Uli Horn - ulihorn", "simfann", "SeaMac", "JupiterRider", "rogerm4242" ]
+contributors = [ "librebob", "Bohdan Matviiv - bodamat", "Michele Comignano - comick", "Matthew - skyace65", "Yann Dirson - ydirson", "IntinteDAO", "Uli Horn - ulihorn", "simfann", "SeaMac", "JupiterRider", "rogerm4242", "nalquas" ]
 translators = [ [ "Bulgarian", "Georgi Georgiev (RacerBG)" ], [ "Ukrainian", "Bohdan Matviiv" ], [ "Polish", "toxicnet" ], [ "Japanese", "paontv" ], [ "Español", "Miguel de Dios Matias" ], [ "Bulgarian", "Georgi - RacerBG" ], [ "French", "Haeroxys", "Miks - Miksimus1" ] ]


### PR DESCRIPTION
Currently, text boxes (as used in the tutorials and to show scenario descriptions on start) use the Godot theme instead of the custom theme used in other parts of the GUI. This pull request fixes that.

I also needed to change the text_box script to use `grab_click_focus()` instead of `grab_focus()` to get the OK button to be readable (not white on white) without first having to click on the message panel.

Before:
![Screenshot_20220414_203744](https://user-images.githubusercontent.com/22664233/163456741-f705f0b6-d1ff-45dd-bd6c-63a4005ddbfc.png)

After (without focus grab fix):
![Screenshot_20220414_204154](https://user-images.githubusercontent.com/22664233/163456812-140966ec-4adb-4561-866b-a0bb08a5df91.png)

After (with focus grab fix):
![Screenshot_20220414_204305](https://user-images.githubusercontent.com/22664233/163456845-a7218597-2b18-4a0c-9228-605e9aa5d066.png)