### PR TITLE
Workaround Godot Editor resetting chunk_unload_distance to 0

### DIFF
--- a/src/addons/jean28518.jTools/jSettings/JSettings.gd
+++ b/src/addons/jean28518.jTools/jSettings/JSettings.gd
@@ -15,7 +15,11 @@ func _ready():
 
 func apply_saved_settings():
 	if ProjectSettings["game/debug/first_run"]:
+		# Workaround Godot resetting default settings in Editor
 		set_fullscreen(true)
+		set_sifa(true)
+		set_pzb(true)
+		set_chunk_unload_distance(2.0)
 		ProjectSettings["game/debug/first_run"] = false
 		save_settings()
 
@@ -132,7 +136,7 @@ func set_pzb(val: bool):
 
 
 func set_chunk_unload_distance(val: float):
-	ProjectSettings["ǵgame/gameplay/chunk_unload_distance"] = int(val)
+	ProjectSettings["game/gameplay/chunk_unload_distance"] = int(val)
 	save_settings()
 
 


### PR DESCRIPTION
Sorry, one more workaround before going to sleep.
Fixes this problem, caused by Godot's Editor resetting chunk_unload_distance to 0 on launch:
![Screenshot_20220417_015230](https://user-images.githubusercontent.com/22664233/163694672-98649ca1-09c1-400c-83ad-37def399b6e7.png)

