### PR TITLE
Apply default settings if override.cfg doesn't exist yet

### DIFF
--- a/src/addons/jean28518.jTools/jSettings/JSettings.gd
+++ b/src/addons/jean28518.jTools/jSettings/JSettings.gd
@@ -17,7 +17,7 @@ func _ready():
 func first_run_check():
 	# Check if this is the first run, and if it is, apply default settings
 	var dir = Directory.new()
-	if not dir.file_exists("user://override.cfg"):
+	if not dir.file_exists("user://override.cfg") or OS.has_feature("editor"):
 		Logger.log("First run (\"user://override.cfg\" doesn't exist). Applying default settings.")
 		set_fullscreen(true)
 		set_vsync(true)

--- a/src/addons/jean28518.jTools/jSettings/JSettings.gd
+++ b/src/addons/jean28518.jTools/jSettings/JSettings.gd
@@ -43,7 +43,9 @@ func apply_saved_settings():
 
 
 func save_settings():
-	ProjectSettings.save_custom("user://override.cfg")
+	# Save, except if in Godot Editor
+	if not OS.has_feature("editor"):
+		ProjectSettings.save_custom("user://override.cfg")
 
 
 func update_settings_window():

--- a/src/addons/jean28518.jTools/jSettings/JSettings.gd
+++ b/src/addons/jean28518.jTools/jSettings/JSettings.gd
@@ -10,19 +10,33 @@ func popup():
 func _ready():
 	if get_parent().name == "root":
 		$JSettings.hide()
+	first_run_check()
 	apply_saved_settings()
 
 
-func apply_saved_settings():
-	if ProjectSettings["game/debug/first_run"]:
-		# Workaround Godot resetting default settings in Editor
+func first_run_check():
+	# Check if this is the first run, and if it is, apply default settings
+	var dir = Directory.new()
+	if not dir.file_exists("user://override.cfg"):
+		Logger.log("First run (\"user://override.cfg\" doesn't exist). Applying default settings.")
 		set_fullscreen(true)
+		set_vsync(true)
+		set_anti_aliasing(2)
+		set_fog(true)
+		set_shadows(true)
+		set_main_volume(1.0)
+		set_music_volume(1.0)
+		set_game_volume(1.0)
+		set_persons(true)
+		set_view_distance(1000)
 		set_sifa(true)
 		set_pzb(true)
-		set_chunk_unload_distance(2.0)
-		ProjectSettings["game/debug/first_run"] = false
-		save_settings()
+		set_chunk_unload_distance(2)
+		set_chunk_load_all(false)
+		set_dynamic_lights(false)
 
+
+func apply_saved_settings():
 	jAudioManager.set_main_volume_db(ProjectSettings["game/audio/main_volume"])
 	jAudioManager.set_game_volume_db(ProjectSettings["game/audio/game_volume"])
 	jAudioManager.set_music_volume_db(ProjectSettings["game/audio/music_volume"])

--- a/src/project.godot
+++ b/src/project.godot
@@ -277,7 +277,7 @@ boot_splash/fullsize=false
 boot_splash/bg_color=Color( 0.65098, 0.65098, 0.65098, 1 )
 config/icon="res://Data/Misc/logos/lts_logo_16.png"
 config/quit_on_go_back=false
-config/custom_user_dir_name.editor="libre_train_sim_godot_editor"
+config/project_settings_override.editor="user://override_dev.cfg"
 
 [audio]
 

--- a/src/project.godot
+++ b/src/project.godot
@@ -277,6 +277,7 @@ boot_splash/fullsize=false
 boot_splash/bg_color=Color( 0.65098, 0.65098, 0.65098, 1 )
 config/icon="res://Data/Misc/logos/lts_logo_16.png"
 config/quit_on_go_back=false
+config/custom_user_dir_name.editor="libre_train_sim_godot_editor"
 
 [audio]
 

--- a/src/project.godot
+++ b/src/project.godot
@@ -328,7 +328,6 @@ gameplay/pzb_enabled=true
 gameplay/chunk_unload_distance=2
 gameplay/load_all_chunks=false
 graphics/enable_dynamic_lights=false
-debug/first_run=true
 
 [global]
 


### PR DESCRIPTION
Instead of relying on a first_launch variable to ensure correct initial settings, simply checking for game-breaking settings on launch should be enough to avoid game-breaking config issues. 

Some points:

- This seems to be a more robust solution than [!356](https://github.com/Libre-TrainSim/Libre-TrainSim/pull/356), and should prevent future issues in this regard. Obviously, chunk_unload_distance shouldn't ever have a value of 0 in the first place, but I'd keep the sanity check in, just in case.
- This change has the side effect of the game launching in windowed mode by default, though I don't see that as a problem.
- The first_launch variable shouldn't be needed in the first place, and assuming correct export procedure, the default values (such as SIFA or PZB) appear to be loaded correctly.
- The issue of Godot Editor overwriting `project.godot` on every launch based on what's written in the developer's user directory (`~/.local/share/libre_train_sim/override.cfg`) remains, though that should be fixed by Godot upstream (see https://github.com/godotengine/godot/issues/30912). Until then, assuming whoever does the final export of the game deletes their `override.cfg` and reverts any changes to their `project.godot` before export (plus maybe restarts Godot), everything should be fine.
- Even if the old workaround would have worked, the `first_launch` variable itself was affected by the bug, thus making it unreliable.