### PR TITLE
Address some warnings

### DIFF
--- a/src/Data/Scripts/HUD.gd
+++ b/src/Data/Scripts/HUD.gd
@@ -17,7 +17,6 @@ func _ready() -> void:
 		$IngameInformation/Next.rect_position.y += 100
 	$Pause.player = player
 	$Black.show()
-	$TextBox.connect("closed", self, "emit_signal", ["textbox_closed"])
 
 
 func _process(_delta: float) -> void:
@@ -109,6 +108,7 @@ func update_nextTable() -> void:
 
 
 func _on_TextBox_closed() -> void:
+	emit_signal("textbox_closed")
 	if $Black.visible:
 		$Black/AnimationPlayer.play("FadeOut")
 

--- a/src/Data/Scripts/Player.gd
+++ b/src/Data/Scripts/Player.gd
@@ -177,7 +177,7 @@ func ready() -> void:
 	# Initiliaze Camera:
 	$Camera.pause_mode = Node.PAUSE_MODE_PROCESS
 	if not ai:
-		$HUD.connect("textbox_closed", self, "emit_signal", ["_textbox_closed"])
+		$HUD.connect("textbox_closed", self, "_on_textbox_closed")
 		cameraZeroTransform = cameraNode.transform
 		cameraX = -$Camera.rotation_degrees.x
 		cameraY = $Camera.rotation_degrees.y
@@ -1197,6 +1197,10 @@ func bake_route() -> void: ## Generate the whole route for the train.
 
 func show_textbox_message(string: String) -> void:
 	$HUD.show_textbox_message(string)
+
+
+func _on_textbox_closed() -> void:
+	emit_signal("_textbox_closed")
 
 
 # returns an sorted array with the names of the signals. The first entry is the nearest.

--- a/src/Data/Scripts/Rail.gd
+++ b/src/Data/Scripts/Rail.gd
@@ -672,4 +672,4 @@ func _update_connection_arrows_not_recursive():
 	else:
 		$Ending/Ending.material_override = preload("res://Data/Misc/Rail_Ending_disconnected.tres")
 
-	_last_calculation_of_update_connection_arrows == get_tree().get_frame()
+	_last_calculation_of_update_connection_arrows = get_tree().get_frame()

--- a/src/Data/Scripts/Singletons/Math.gd
+++ b/src/Data/Scripts/Singletons/Math.gd
@@ -93,6 +93,8 @@ func time2String(time: Array) -> String:
 	return (hour + ":" + minute +":" + second)
 
 func seconds_to_string(time_seconds: int) -> String:
+	# warning-ignore:integer_division
+	# warning-ignore:integer_division
 	return "%02d:%02d:%02d" % [time_seconds/3600, (time_seconds/60)%60, time_seconds%60]
 
 
@@ -111,9 +113,9 @@ func time_to_seconds(time: Array) -> int:
 
 func seconds_to_time(seconds: int) -> Array:
 	var time: Array = [0, 0, 0]
-	time[0] = int(seconds/3600)
+	time[0] = seconds/3600 # warning-ignore: integer_division
 	seconds -= time[0] * 3600
-	time[1] = int(seconds/60)
+	time[1] = seconds/60 # warning-ignore: integer_division
 	seconds -= time[1] * 60
 	time[2] = seconds
 	return time

--- a/src/Data/Scripts/Singletons/Root.gd
+++ b/src/Data/Scripts/Singletons/Root.gd
@@ -116,9 +116,8 @@ func checkAndLoadTranslationsForTrain(trainDirPath: String) -> void:
 # the result is saved to the 'found_files' variable
 func crawl_directory(found_files: Array, directory_path: String, file_extensions: Array, recursion_depth: int = -1) -> void:
 	var dir := Directory.new()
-	if dir.open(directory_path) != OK:
+	if dir.open(directory_path) != OK or dir.list_dir_begin(true, true) != OK:
 		return
-	dir.list_dir_begin(true, true)
 
 	while true:
 		var file: String = dir.get_next()
@@ -138,9 +137,8 @@ func crawl_directory(found_files: Array, directory_path: String, file_extensions
 
 func get_subfolders_of(directory_path: String) -> Array:
 	var dir := Directory.new()
-	if dir.open(directory_path) != OK:
+	if dir.open(directory_path) != OK or dir.list_dir_begin(true, true) != OK:
 		return []
-	dir.list_dir_begin(true, true)
 	var folder_names: Array = []
 	while(true):
 		var file: String = dir.get_next()

--- a/src/Data/Scripts/Singletons/Root.gd
+++ b/src/Data/Scripts/Singletons/Root.gd
@@ -177,3 +177,7 @@ func set_low_resolution(value: bool) -> void:
 		ProjectSettings.set_setting("display/window/stretch/aspect", "ignore")
 		ProjectSettings.set_setting("display/window/size/width", "800")
 		ProjectSettings.set_setting("display/window/size/height", "600")
+
+
+func world_origin_shifted(delta) -> void:
+	emit_signal("world_origin_shifted", delta)

--- a/src/Data/Scripts/Singletons/content_loader.gd
+++ b/src/Data/Scripts/Singletons/content_loader.gd
@@ -209,7 +209,6 @@ func get_scenarios_for_track(track: String) -> Array:
 
 # If train_name is part of the path, this function returns the whole path
 func find_train_path(train_name: String) -> String:
-	var train_path: String = ""
 	for available_train_path in ContentLoader.repo.trains:
 		if available_train_path.find(train_name) != -1:
 			return available_train_path

--- a/src/Data/Scripts/StationJumper.gd
+++ b/src/Data/Scripts/StationJumper.gd
@@ -10,7 +10,6 @@ signal station_index_selected(station_index)
 func update_list(player: Spatial) -> void:
 	$StationJumper/ItemList.clear()
 	current_station_indices.clear()
-	var stations: Array = player.station_table
 	for station_index in range(player.current_station_table_index, player.station_table.size()):
 		current_station_indices.append(station_index)
 	if player.is_in_station:

--- a/src/Data/Scripts/World.gd
+++ b/src/Data/Scripts/World.gd
@@ -140,16 +140,15 @@ func get_signal_scenario_data() -> Dictionary:
 	return signals
 
 
-var train_spawn_information: Dictionary = {
-	time = 0,
-	player_train = false,
-	train_path = "",
-	route_name = "",
-	minimal_platform_length = 0,
-	route = [],
-	station_table = [],
-	despawn_information = {}
-}
+class TrainSpawnInformation:
+	var time = 0
+	var player_train = false
+	var train_path = ""
+	var route_name = ""
+	var minimal_platform_length = 0
+	var route = []
+	var station_table = []
+	var despawn_information = {}
 
 
 func set_scenario_to_world() -> void:
@@ -187,7 +186,7 @@ func set_scenario_to_world() -> void:
 			# If the spawn time was before our start time, or the start time is above 2.5 hours
 			if available_time < time or available_time - time > (3600*2.5):
 				continue
-			var pending_train_spawn: Dictionary = train_spawn_information.duplicate(true)
+			var pending_train_spawn = TrainSpawnInformation.new()
 			pending_train_spawn.time = available_time
 			pending_train_spawn.train_path = train_path
 			# Player Train:
@@ -206,7 +205,7 @@ func set_scenario_to_world() -> void:
 	jEssentials.call_delayed(1, $Players/Player, "show_textbox_message", [tr(routes[Root.selected_route].general_settings.description)])
 
 
-func spawn_train(train_spawn_information: Dictionary) -> void:
+func spawn_train(train_spawn_information: TrainSpawnInformation) -> void:
 	var new_train: Node = load(train_spawn_information.train_path).instance()
 	if train_spawn_information.player_train:
 		new_train.name = "Player"

--- a/src/Data/Scripts/chunk_manager.gd
+++ b/src/Data/Scripts/chunk_manager.gd
@@ -107,7 +107,7 @@ func _exit_tree():
 	_halt_thread()
 
 
-func _process(delta: float):
+func _process(_delta: float):
 	assert(world != null)
 
 	# get position of active camera

--- a/src/Data/Scripts/chunk_manager.gd
+++ b/src/Data/Scripts/chunk_manager.gd
@@ -351,7 +351,7 @@ func _chunk_loader_thread(_void):
 
 		_chunk_mutex.unlock()
 		_saving_mutex.unlock()
-		call_deferred("emit_signal", "_thread_finished_loading")
+		call_deferred("_emit_thread_finished_loading")
 
 
 func _generate_landscape(chunk, chunk_pos):
@@ -367,3 +367,7 @@ func _generate_landscape(chunk, chunk_pos):
 	else:
 		# TODO: load landscape (heightmap, whatever), not implemented yet
 		pass
+
+
+func _emit_thread_finished_loading() -> void:
+	emit_signal("_thread_finished_loading")

--- a/src/Data/Scripts/chunk_manager.gd
+++ b/src/Data/Scripts/chunk_manager.gd
@@ -134,7 +134,7 @@ func _shift_world_origin_to(position: Vector3):
 	_chunk_mutex.lock()
 	var delta: Vector3 = position - world_origin
 	world_origin = position
-	Root.emit_signal("world_origin_shifted", delta)
+	Root.world_origin_shifted(delta)
 	_chunk_mutex.unlock()
 
 

--- a/src/Data/UI/debug_ui.gd
+++ b/src/Data/UI/debug_ui.gd
@@ -5,7 +5,6 @@ onready var fps_label = $DebugContainer/FPSContainer/FPSLabel
 
 func _process(delta: float) -> void:
 	fps_label.text = str(int(Engine.get_frames_per_second()))
-	$DebugContainer.mouse_filter
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("open_debug_ui"):

--- a/src/Data/UI/debug_ui.gd
+++ b/src/Data/UI/debug_ui.gd
@@ -3,7 +3,7 @@ extends CanvasLayer
 onready var fps_label = $DebugContainer/FPSContainer/FPSLabel
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	fps_label.text = str(int(Engine.get_frames_per_second()))
 
 func _unhandled_input(event: InputEvent) -> void:

--- a/src/Data/UI/play_menu.gd
+++ b/src/Data/UI/play_menu.gd
@@ -151,7 +151,7 @@ func _make_image(path: String) -> Texture:
 	return screenshot_texture
 
 
-func _on_Tracks_item_activated(index) -> void:
+func _on_Tracks_item_activated(_index) -> void:
 	_on_Tracks_Select_pressed()
 
 
@@ -190,7 +190,7 @@ func _on_Scenarios_Select_pressed():
 	update_routes()
 
 
-func _on_Scenarios_item_activated(index):
+func _on_Scenarios_item_activated(_index):
 	_on_Scenarios_Select_pressed()
 
 
@@ -214,7 +214,7 @@ func _on_Routes_Select_pressed():
 	update_times()
 
 
-func _on_Routes_ItemList_item_activated(index):
+func _on_Routes_ItemList_item_activated(_index):
 	_on_Routes_Select_pressed()
 
 
@@ -228,7 +228,7 @@ func _on_Times_Select_pressed():
 	update_trains()
 
 
-func _on_Times_ItemList_item_activated(index):
+func _on_Times_ItemList_item_activated(_index):
 	_on_Times_Select_pressed()
 
 
@@ -283,5 +283,5 @@ func _on_Trains_Play_pressed():
 	load_game()
 
 
-func _on_Trains_item_activated(index):
+func _on_Trains_item_activated(_index):
 	_on_Trains_Play_pressed()

--- a/src/Editor/Docks/RailAttachments/RailAttachments.gd
+++ b/src/Editor/Docks/RailAttachments/RailAttachments.gd
@@ -226,7 +226,7 @@ func _on_jListTrackObjects_user_copied_entries(entry_names: Array) -> void:
 	Logger.log("TrackObject(s) copied. Please don't delete the TrackObject(s), until you pasted a copy of it/them.")
 
 
-func _on_jListTrackObjects_user_pasted_entries(source_entry_names: Array, source_jList_id, pasted_entry_names: Array) -> void:
+func _on_jListTrackObjects_user_pasted_entries(_source_entry_names: Array, _source_jList_id, pasted_entry_names: Array) -> void:
 	assert(pasted_entry_names.size() == copyTOArray.size())
 	for i in range (pasted_entry_names.size()):
 		copy_track_object_to_current_rail(copyTOArray[i], pasted_entry_names[i], $Tab/TrackObjects/MirrorPastedObjects.pressed)

--- a/src/Editor/Docks/RailAttachments/RailAttachments.gd
+++ b/src/Editor/Docks/RailAttachments/RailAttachments.gd
@@ -13,7 +13,7 @@ var pluginRoot
 var track_object_resource: PackedScene = preload("res://Data/Modules/TrackObjects.tscn")
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	$Tab/TrackObjects/Settings.visible = is_instance_valid(currentTO)
 
 

--- a/src/Editor/Docks/RailBuilder/RailBuilder.gd
+++ b/src/Editor/Docks/RailBuilder/RailBuilder.gd
@@ -403,9 +403,9 @@ func _on_OverheadLine_pressed() -> void:
 	currentRail.update()
 
 
-func _on_LineEdit_text_entered(new_text: String) -> void:
+func _on_LineEdit_text_entered(_new_text: String) -> void:
 	_on_Update_pressed()
 
 
-func _on_RenameLine_text_entered(new_text: String) -> void:
+func _on_RenameLine_text_entered(_new_text: String) -> void:
 	_on_Rename_pressed()

--- a/src/Editor/Docks/RailBuilder/RailBuilder.gd
+++ b/src/Editor/Docks/RailBuilder/RailBuilder.gd
@@ -380,9 +380,7 @@ func update_generalInformation() -> void:
 
 func _on_ManualMoving_pressed() -> void:
 	currentRail.manualMoving = $ManualMoving.pressed
-	var editor: Node = find_parent("Editor")
-	if editor:
-		editor.set_selected_object(currentRail)
+	editor.set_selected_object(currentRail)
 
 
 func _on_automaticTendency_pressed() -> void:

--- a/src/Editor/Docks/RailBuilder/RailBuilder.gd
+++ b/src/Editor/Docks/RailBuilder/RailBuilder.gd
@@ -6,7 +6,7 @@ var currentRail: Node
 var eds # Editor Selection
 
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if editor:
 		visible = is_instance_valid(currentRail) and get_parent().current_tab == 1
 

--- a/src/Editor/Modules/Collider2D.gd
+++ b/src/Editor/Modules/Collider2D.gd
@@ -4,7 +4,7 @@ extends Area2D
 var input_handling_node: Node
 
 
-func _on_Collider_input_event(viewport, event, shape_idx) -> void:
+func _on_Collider_input_event(_viewport, event, _shape_idx) -> void:
 	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and not event.pressed:
 		input_handling_node._item_selected(get_parent().name, get_parent().get_parent().name)
 

--- a/src/Editor/Modules/Content_Selector.gd
+++ b/src/Editor/Modules/Content_Selector.gd
@@ -6,7 +6,7 @@ enum {MATERIALS, OBJECTS, RAIL_TYPES, SIGNAL_TYPES, SOUNDS, TEXTURES}
 signal resource_selected(complete_path)
 
 
-func _input(event):
+func _input(_event):
 	if visible and Input.is_action_just_pressed("ui_accept"):
 		emit_selected_resource()
 
@@ -75,11 +75,11 @@ func update_ItemList():
 	$ItemList.sort_items_by_text()
 
 
-func _on_LineEdit_text_changed(new_text):
+func _on_LineEdit_text_changed(_new_text):
 	update_ItemList()
 
 
-func _on_ItemList_item_activated(index):
+func _on_ItemList_item_activated(_index):
 	emit_selected_resource()
 
 

--- a/src/Editor/Modules/Rail2DCollider.gd
+++ b/src/Editor/Modules/Rail2DCollider.gd
@@ -56,6 +56,6 @@ func _ready():
 	collision_polygon_2d.polygon = polygon_points
 
 
-func _on_RailCollider_input_event(viewport, event, shape_idx):
+func _on_RailCollider_input_event(_viewport, event, _shape_idx):
 	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and not event.pressed:
 		input_handling_node._item_selected(name, get_parent().name)

--- a/src/Editor/Modules/RailLogic.gd
+++ b/src/Editor/Modules/RailLogic.gd
@@ -38,8 +38,9 @@ func update_general_settings_ui():
 
 
 func _on_Distance_value_changed(value):
-	$GeneralSettings/Distance.value = clamp($GeneralSettings/Distance.value, 0, find_parent("Editor").get_rail(current_rail_logic.attached_rail).length)
-	current_rail_logic.on_rail_position = $GeneralSettings/Distance.value
+	value = clamp(value, 0, find_parent("Editor").get_rail(current_rail_logic.attached_rail).length)
+	$GeneralSettings/Distance.value = value
+	current_rail_logic.on_rail_position = value
 	current_rail_logic.set_to_rail()
 
 
@@ -103,7 +104,7 @@ func _on_StationName_text_entered(new_text):
 
 
 func _on_Length_value_changed(value):
-	current_rail_logic.length = $StationSettings/Length.value
+	current_rail_logic.length = value
 
 
 func _on_PlatformSide_item_selected(index):
@@ -131,7 +132,7 @@ func update_speed_limit_settings_ui():
 
 
 func _on_SpeedLimit_SpeedLimit_value_changed(value):
-	current_rail_logic.speed = $SpeedLimitSettings/SpeedLimit.value
+	current_rail_logic.speed = value
 	current_rail_logic.set_to_rail()
 
 
@@ -140,12 +141,12 @@ func update_warn_speed_limit_settings_ui():
 
 
 func _on_WarnSpeedLimit_value_changed(value):
-	current_rail_logic.warn_speed = $WarnSpeedLimitSettings/SpeedLimit.value
+	current_rail_logic.warn_speed = value
 	current_rail_logic.set_to_rail()
 
 
 func _on_ConnectedSignal_text_changed(new_text):
-	current_rail_logic.assigned_signal = $StationSettings/AssignedSignal.text
+	current_rail_logic.assigned_signal = new_text
 
 
 func _on_selected_rail_logic_deleted():

--- a/src/Editor/Modules/building_settings.gd
+++ b/src/Editor/Modules/building_settings.gd
@@ -24,7 +24,7 @@ func _ready():
 		possible_materials[material.get_file().get_basename()] = material
 
 
-func _input(event):
+func _input(_event):
 	if visible and not is_instance_valid(current_mesh):
 		Logger.warn("current_mesh was deleted but the building settings haven't been updated!", self)
 		hide()

--- a/src/Editor/Scripts/EditorHUD.gd
+++ b/src/Editor/Scripts/EditorHUD.gd
@@ -95,22 +95,22 @@ func _on_SaveWithoutExit_pressed():
 
 func _on_x_value_changed(value):
 	var selected_object = get_parent().selected_object
-	selected_object.translation.x = $ObjectTransform/HBoxContainer/x.value
+	selected_object.translation.x = value
 
 
 func _on_y_value_changed(value):
 	var selected_object = get_parent().selected_object
-	selected_object.translation.y = $ObjectTransform/HBoxContainer/y.value
+	selected_object.translation.y = value
 
 
 func _on_z_value_changed(value):
 	var selected_object = get_parent().selected_object
-	selected_object.translation.z = $ObjectTransform/HBoxContainer/z.value
+	selected_object.translation.z = value
 
 
 func _on_y_rot_value_changed(value):
 	var selected_object = get_parent().selected_object
-	selected_object.rotation_degrees.y = $ObjectTransform/HBoxContainer/y_rot.value
+	selected_object.rotation_degrees.y = value
 
 
 func _onObjectName_text_entered(_new_text):

--- a/src/Editor/Scripts/EditorHUD.gd
+++ b/src/Editor/Scripts/EditorHUD.gd
@@ -113,7 +113,7 @@ func _on_y_rot_value_changed(value):
 	selected_object.rotation_degrees.y = $ObjectTransform/HBoxContainer/y_rot.value
 
 
-func _onObjectName_text_entered(new_text):
+func _onObjectName_text_entered(_new_text):
 	_on_CurrentObjectRename_pressed()
 
 

--- a/src/Editor/Scripts/EditorHUD.gd
+++ b/src/Editor/Scripts/EditorHUD.gd
@@ -13,7 +13,7 @@ func handle_object_transform_field():
 		$ObjectTransform/HBoxContainer/y_rot.value = selected_object.rotation_degrees.y
 
 
-func _unhandled_input(event: InputEvent) -> void:
+func _unhandled_input(_event: InputEvent) -> void:
 	if Input.is_action_just_pressed("Escape"):
 		if $Pause.visible:
 			_on_Pause_Back_pressed()

--- a/src/Editor/Scripts/Gizmo.gd
+++ b/src/Editor/Scripts/Gizmo.gd
@@ -28,8 +28,6 @@ func _input(event):
 func _process(delta):
 	rotation_degrees.y = - get_parent().rotation_degrees.y
 
-	var screen_size = get_viewport().size
-
 	if Input.is_mouse_button_pressed(BUTTON_LEFT) and (x_active or y_active or z_active or x_rot_active):
 		Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 		if x_active:

--- a/src/Editor/Scripts/Gizmo.gd
+++ b/src/Editor/Scripts/Gizmo.gd
@@ -25,7 +25,7 @@ func _input(event):
 			Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 
 
-func _process(delta):
+func _process(_delta):
 	rotation_degrees.y = - get_parent().rotation_degrees.y
 
 	if Input.is_mouse_button_pressed(BUTTON_LEFT) and (x_active or y_active or z_active or x_rot_active):

--- a/src/Editor/Scripts/ScenarioConfiguration.gd
+++ b/src/Editor/Scripts/ScenarioConfiguration.gd
@@ -45,7 +45,7 @@ func init():
 
 
 
-func _input(event):
+func _input(_event):
 	if Input.is_action_just_pressed("save"):
 		save()
 
@@ -287,7 +287,7 @@ func update_route_point_settings():
 		update_despawn_point_settings()
 
 
-func _on_RouteList_ItemList_item_selected(index):
+func _on_RouteList_ItemList_item_selected(_index):
 	update_route_point_settings()
 
 

--- a/src/Editor/Scripts/scenario_editor_selection.gd
+++ b/src/Editor/Scripts/scenario_editor_selection.gd
@@ -84,7 +84,7 @@ func _on_scenarioList_user_pressed_action(entry_names):
 
 
 # TrackList:
-func _on_ItemList_item_activated(index):
+func _on_ItemList_item_activated(_index):
 	_on_Select_TrackList_pressed()
 
 

--- a/src/Editor/Scripts/scenario_editor_selection.gd
+++ b/src/Editor/Scripts/scenario_editor_selection.gd
@@ -2,8 +2,6 @@ extends Panel
 
 var selected_track: String = ""
 
-var available_scenarios = []
-
 var j_save_module = jSaveModule.new()
 
 func update_track_list():

--- a/src/Editor/Scripts/scenario_map.gd
+++ b/src/Editor/Scripts/scenario_map.gd
@@ -29,12 +29,6 @@ var label_mask: Dictionary = {
 signal item_selected(path)
 
 
-func _process(delta : float) -> void:
-	var movement = mouse_motion * $Camera2D.zoom.x
-	$Camera2D.position += movement
-	mouse_motion = Vector2(0,0)
-
-
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action("zoom_in"):
 		var zoom = $Camera2D.zoom
@@ -52,6 +46,9 @@ func _unhandled_input(event: InputEvent) -> void:
 
 	if event is InputEventMouseMotion and Input.is_mouse_button_pressed(BUTTON_MIDDLE):
 		mouse_motion -= event.relative
+		var movement = mouse_motion * $Camera2D.zoom.x
+		$Camera2D.position += movement
+		mouse_motion = Vector2(0,0)
 		get_tree().set_input_as_handled()
 
 

--- a/src/Editor/Scripts/scenario_map.gd
+++ b/src/Editor/Scripts/scenario_map.gd
@@ -145,13 +145,13 @@ func create_line2d_from_rail(rail, special: bool = false):
 		$RailsSelection.add_child(line)
 		line.default_color = Color("2891c5")
 
-func init(world : Node):
-	self.world = world
-	var rails = world.get_node("Rails").get_children()
+func init(new_world : Node):
+	world = new_world
+	var rails = new_world.get_node("Rails").get_children()
 	for rail in rails:
 		create_line2d_from_rail(rail)
 
-	var signals = world.get_node("Signals").get_children()
+	var signals = new_world.get_node("Signals").get_children()
 	for signal_instance in signals:
 		if signal_instance.type == "Station" or signal_instance.type == "Signal"\
 				or  signal_instance.type == "ContactPoint":


### PR DESCRIPTION
Godot currently throws a *lot* of warnings (far over 100 at times...).
I've gone through them and fixed some stuff I came across.

Changes include:

- Remove some unused variables
- Remove/correct some lines that have no effect
- Some variable shadowing warnings addressed
- Follow Godot conventions regarding underscores on parameters that aren't used
- Don't call emit_signal on other scenes directly, but instead provide functions where needed
- Ignore those pesky integer division warnings of Math.gd

This should take care of most of the warnings, however a lot of warnings along the lines of `The function ... returns a value, but this value is never used.` remain.