### PR TITLE
Fix overhead line being visible after load despite being disabled

### DIFF
--- a/src/Data/Scripts/Rail.gd
+++ b/src/Data/Scripts/Rail.gd
@@ -155,6 +155,11 @@ func _update() -> void:
 
 	if overheadLine:
 		update_overheadline(calculate_overhadline_mesh())
+	else:
+		# Fix overhead line being visible on load despite being disabled
+		var that_overhead_line = get_node_or_null("OverheadLine")
+		if that_overhead_line != null:
+			that_overhead_line.queue_free()
 
 	if Root.Editor and visible:
 		$Ending.transform = get_local_transform_at_rail_distance(length)


### PR DESCRIPTION
Fixes #366.

It seems to be working fine and side-effect free (I was able to edit/save/reload a track, and the tutorial track works as normal).
Please do test it for yourself before merging, though.

Here's a video following the reproduction steps from the issue:

https://user-images.githubusercontent.com/22664233/172705937-36785520-86cd-4017-9716-972582422b76.mp4


