### PR TITLE
Prefer queue_free() over free() where appropriate

### DIFF
--- a/src/Data/Scripts/Rail.gd
+++ b/src/Data/Scripts/Rail.gd
@@ -174,9 +174,9 @@ func _update() -> void:
 func unload_visible_instance() -> void:
 	visible = false
 	if get_node_or_null("MultiMeshInstance") != null:
-		$MultiMeshInstance.free()
+		$MultiMeshInstance.queue_free()
 	if get_node_or_null("OverheadLine") != null:
-		$OverheadLine.free()
+		$OverheadLine.queue_free()
 	for track_object in trackObjects:
 		if is_instance_valid(track_object):
 			track_object.queue_free()

--- a/src/Editor/Docks/RailBuilder/RailBuilder.gd
+++ b/src/Editor/Docks/RailBuilder/RailBuilder.gd
@@ -175,7 +175,7 @@ func _on_Rename_pressed() -> void:
 
 
 func _on_Delete_pressed() -> void:
-	currentRail.free()
+	currentRail.queue_free()
 	currentRail = null
 	update_selected_rail(self)
 	Logger.log("Rail deleted.")

--- a/src/Editor/Scripts/ScenarioConfiguration.gd
+++ b/src/Editor/Scripts/ScenarioConfiguration.gd
@@ -154,7 +154,7 @@ func update_ui_for_current_route():
 	$TabContainer/Routes/RouteConfiguration/GeneralSettings/P.visible = routes[current_route].general_settings.activate_only_at_specific_routes and not routes[current_route].general_settings.player_can_drive_this_route
 
 	for child in $TabContainer/Routes/RouteConfiguration/GeneralSettings/P/SpecificRoutes.get_children():
-		child.free()
+		child.queue_free()
 	for route_name in routes.keys():
 		if routes[route_name].general_settings.player_can_drive_this_route and route_name != current_route:
 			var checkbox: CheckBox = CheckBox.new()

--- a/src/Editor/Scripts/scenario_map.gd
+++ b/src/Editor/Scripts/scenario_map.gd
@@ -173,9 +173,9 @@ func update_map():
 
 	# Clear old selection:
 	for child in $Special.get_children():
-		child.free()
+		child.queue_free()
 	for child in $RailsSelection.get_children():
-		child.free()
+		child.queue_free()
 
 	if label_mask.signals:
 		for signal_instance in $Signals.get_children():

--- a/src/addons/jean28518.jTools/jTable/jTable.gd
+++ b/src/addons/jean28518.jTools/jTable/jTable.gd
@@ -48,10 +48,10 @@ func update_table_in_editor(newvar):
 func clear():
 	current_entries = 0
 	for child in grid_node.get_children():
-		child.free()
+		child.queue_free()
 
 	for heading in headings_node.get_children():
-		heading.free()
+		heading.queue_free()
 
 func initialize():
 	if not check_configuration():


### PR DESCRIPTION
This pull request replaces all remaining uses of `free()` with `queue_free()`.
My reasoning behind this is that `queue_free()`, contrary to `free()`, ensures it's safe to delete a node ([according to Godot Docs](https://docs.godotengine.org/en/stable/classes/class_node.html?highlight=queue_free()#class-node-method-queue-free)), and thus should be more reliable.

Please test for side-effects.