### PR TITLE
Refactor configuration into window

### DIFF
--- a/src/Editor/Docks/Configuration/Configuration.gd
+++ b/src/Editor/Docks/Configuration/Configuration.gd
@@ -1,34 +1,55 @@
-extends Control
+extends WindowDialog
 
 
 var save_path := ""
-
-var j_save_module = jSaveModule.new()
+var j_save_module := jSaveModule.new()
 
 
 func _ready() -> void:
 	save_path = find_parent("Editor").current_track_path + ".trackinfo"
 	j_save_module.set_save_path(save_path)
-	update_save_pathuration()
+	load_stored_config()
 
 
-func save_everything() -> void:
-	_on_SaveWorldConfig_pressed()
+func _unhandled_key_input(_event: InputEventKey) -> void:
+	if Input.is_action_just_released("ui_cancel", true):
+		# There seems to be an issue with event propagation
+		# Hence we wait for the frame to end before we actually hide it
+		# because otherwise we immediately open the pause menu.
+		call_deferred("hide")
 
 
-func _on_SaveWorldConfig_pressed() -> void:
-	j_save_module.save_value("author", $GridContainer/Author.text)
-	j_save_module.save_value("release_date", [$GridContainer/ReleaseDate/Day.value, $GridContainer/ReleaseDate/Month.value, $GridContainer/ReleaseDate/Year.value])
-	j_save_module.save_value("description", $GridContainer/TrackDescription.text)
-	j_save_module.save_value("editor_notes", $Notes.text)
+func save_config() -> void:
+	j_save_module.save_value("author", $Configuration/GridContainer/Author.text)
+	j_save_module.save_value("release_date", [$Configuration/GridContainer/ReleaseDate/Day.value, $Configuration/GridContainer/ReleaseDate/Month.value, $Configuration/GridContainer/ReleaseDate/Year.value])
+	j_save_module.save_value("description", $Configuration/GridContainer/TrackDescription.text)
+	j_save_module.save_value("editor_notes", $Configuration/Notes.text)
 	j_save_module.write_to_disk()
 	Logger.log("Trackinfo saved.")
 
 
-func update_save_pathuration() -> void:
-	$GridContainer/ReleaseDate/Day.value = j_save_module.get_value("release_date", [1, 1, 2021])[0]
-	$GridContainer/ReleaseDate/Month.value = j_save_module.get_value("release_date", [1, 1, 2021])[1]
-	$GridContainer/ReleaseDate/Year.value = j_save_module.get_value("release_date", [1, 1, 2021])[2]
-	$GridContainer/Author.text = j_save_module.get_value("author", "Unknown")
-	$GridContainer/TrackDescription.text = j_save_module.get_value("description", "")
-	$Notes.text = j_save_module.get_value("editor_notes", "")
+func load_stored_config() -> void:
+	$Configuration/GridContainer/ReleaseDate/Day.value = j_save_module.get_value("release_date", [1, 1, 2021])[0]
+	$Configuration/GridContainer/ReleaseDate/Month.value = j_save_module.get_value("release_date", [1, 1, 2021])[1]
+	$Configuration/GridContainer/ReleaseDate/Year.value = j_save_module.get_value("release_date", [1, 1, 2021])[2]
+	$Configuration/GridContainer/Author.text = j_save_module.get_value("author", "Unknown")
+	$Configuration/GridContainer/TrackDescription.text = j_save_module.get_value("description", "")
+	$Configuration/Notes.text = j_save_module.get_value("editor_notes", "")
+
+
+func _on_Cancel_pressed() -> void:
+	hide()
+
+
+func _on_Save_pressed() -> void:
+	save_config()
+	hide()
+
+
+func _on_about_to_show() -> void:
+	get_tree().paused = true
+
+
+func _on_popup_hide() -> void:
+	get_tree().paused = false
+	queue_free()

--- a/src/Editor/Docks/Configuration/Configuration.tscn
+++ b/src/Editor/Docks/Configuration/Configuration.tscn
@@ -2,41 +2,45 @@
 
 [ext_resource path="res://Editor/Docks/Configuration/Configuration.gd" type="Script" id=1]
 
-[node name="Configuration" type="VBoxContainer"]
-anchor_left = 1.0
+[node name="ConfirmationDialog" type="WindowDialog"]
+pause_mode = 2
+anchor_left = 0.1
+anchor_top = 0.1
+anchor_right = 0.9
+anchor_bottom = 0.9
+popup_exclusive = true
+window_title = "Edit Configuration"
+script = ExtResource( 1 )
+
+[node name="Configuration" type="VBoxContainer" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = -357.0
-script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Label2" type="Label" parent="."]
-margin_right = 357.0
+[node name="Label2" type="Label" parent="Configuration"]
+margin_right = 819.0
 margin_bottom = 14.0
 text = "World Configuration:"
 align = 1
 
-[node name="GridContainer" type="GridContainer" parent="."]
+[node name="GridContainer" type="GridContainer" parent="Configuration"]
 margin_top = 18.0
-margin_right = 357.0
+margin_right = 819.0
 margin_bottom = 174.0
 columns = 2
 
-[node name="Label2" type="Label" parent="GridContainer"]
+[node name="Label2" type="Label" parent="Configuration/GridContainer"]
 margin_top = 5.0
 margin_right = 115.0
 margin_bottom = 19.0
 text = "Release Date:"
 
-[node name="ReleaseDate" type="HBoxContainer" parent="GridContainer"]
+[node name="ReleaseDate" type="HBoxContainer" parent="Configuration/GridContainer"]
 margin_left = 119.0
-margin_right = 357.0
+margin_right = 819.0
 margin_bottom = 24.0
 
-[node name="Day" type="SpinBox" parent="GridContainer/ReleaseDate"]
-margin_right = 76.0
+[node name="Day" type="SpinBox" parent="Configuration/GridContainer/ReleaseDate"]
+margin_right = 230.0
 margin_bottom = 24.0
 hint_tooltip = "Day"
 size_flags_horizontal = 3
@@ -45,9 +49,9 @@ max_value = 31.0
 value = 1.0
 suffix = "D"
 
-[node name="Month" type="SpinBox" parent="GridContainer/ReleaseDate"]
-margin_left = 80.0
-margin_right = 157.0
+[node name="Month" type="SpinBox" parent="Configuration/GridContainer/ReleaseDate"]
+margin_left = 234.0
+margin_right = 465.0
 margin_bottom = 24.0
 hint_tooltip = "Month
 "
@@ -57,9 +61,9 @@ max_value = 12.0
 value = 1.0
 suffix = "M"
 
-[node name="Year" type="SpinBox" parent="GridContainer/ReleaseDate"]
-margin_left = 161.0
-margin_right = 238.0
+[node name="Year" type="SpinBox" parent="Configuration/GridContainer/ReleaseDate"]
+margin_left = 469.0
+margin_right = 700.0
 margin_bottom = 24.0
 hint_tooltip = "Month
 "
@@ -70,54 +74,76 @@ value = 2020.0
 allow_greater = true
 suffix = "Y"
 
-[node name="Label3" type="Label" parent="GridContainer"]
+[node name="Label3" type="Label" parent="Configuration/GridContainer"]
 margin_top = 33.0
 margin_right = 115.0
 margin_bottom = 47.0
 text = "Author Name(s):"
 
-[node name="Author" type="LineEdit" parent="GridContainer"]
+[node name="Author" type="LineEdit" parent="Configuration/GridContainer"]
 margin_left = 119.0
 margin_top = 28.0
-margin_right = 357.0
+margin_right = 819.0
 margin_bottom = 52.0
 size_flags_horizontal = 3
 caret_blink = true
 
-[node name="Label4" type="Label" parent="GridContainer"]
+[node name="Label4" type="Label" parent="Configuration/GridContainer"]
 margin_top = 99.0
 margin_right = 115.0
 margin_bottom = 113.0
 text = "Track Description:"
 
-[node name="TrackDescription" type="TextEdit" parent="GridContainer"]
+[node name="TrackDescription" type="TextEdit" parent="Configuration/GridContainer"]
 margin_left = 119.0
 margin_top = 56.0
-margin_right = 357.0
+margin_right = 819.0
 margin_bottom = 156.0
 rect_min_size = Vector2( 0, 100 )
 size_flags_horizontal = 3
 
-[node name="Label" type="Label" parent="."]
+[node name="Label" type="Label" parent="Configuration"]
 margin_top = 178.0
-margin_right = 357.0
+margin_right = 819.0
 margin_bottom = 192.0
 text = "Notes for Authors:"
 align = 1
 
-[node name="Notes" type="TextEdit" parent="."]
+[node name="Notes" type="TextEdit" parent="Configuration"]
 margin_top = 196.0
-margin_right = 357.0
-margin_bottom = 576.0
+margin_right = 819.0
+margin_bottom = 452.0
 rect_min_size = Vector2( 0, 100 )
 size_flags_vertical = 3
 
-[node name="SaveWorldConfig" type="Button" parent="."]
-margin_left = 157.0
-margin_top = 580.0
-margin_right = 200.0
-margin_bottom = 600.0
-size_flags_horizontal = 4
-text = "SAVE"
+[node name="MarginContainer" type="MarginContainer" parent="Configuration"]
+margin_top = 456.0
+margin_right = 819.0
+margin_bottom = 480.0
+custom_constants/margin_right = 4
+custom_constants/margin_left = 4
+custom_constants/margin_bottom = 4
 
-[connection signal="pressed" from="SaveWorldConfig" to="." method="_on_SaveWorldConfig_pressed"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Configuration/MarginContainer"]
+margin_left = 4.0
+margin_right = 815.0
+margin_bottom = 20.0
+alignment = 1
+
+[node name="Save" type="Button" parent="Configuration/MarginContainer/HBoxContainer"]
+margin_right = 403.0
+margin_bottom = 20.0
+size_flags_horizontal = 3
+text = "Save"
+
+[node name="Cancel" type="Button" parent="Configuration/MarginContainer/HBoxContainer"]
+margin_left = 407.0
+margin_right = 811.0
+margin_bottom = 20.0
+size_flags_horizontal = 3
+text = "Cancel"
+
+[connection signal="about_to_show" from="." to="." method="_on_about_to_show"]
+[connection signal="popup_hide" from="." to="." method="_on_popup_hide"]
+[connection signal="pressed" from="Configuration/MarginContainer/HBoxContainer/Save" to="." method="_on_Save_pressed"]
+[connection signal="pressed" from="Configuration/MarginContainer/HBoxContainer/Cancel" to="." method="_on_Cancel_pressed"]

--- a/src/Editor/Docks/RailBuilder/RailBuilder.gd
+++ b/src/Editor/Docks/RailBuilder/RailBuilder.gd
@@ -8,7 +8,7 @@ var eds # Editor Selection
 
 func _process(_delta: float) -> void:
 	if editor:
-		visible = is_instance_valid(currentRail) and get_parent().current_tab == 1
+		visible = is_instance_valid(currentRail) and get_parent().current_tab == 0
 
 
 func update_selected_rail(node: Node) -> void:

--- a/src/Editor/Editor.tscn
+++ b/src/Editor/Editor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=2]
+[gd_scene load_steps=15 format=2]
 
 [ext_resource path="res://Editor/Scripts/editor_camera.gd" type="Script" id=1]
 [ext_resource path="res://Editor/Scripts/Editor.gd" type="Script" id=2]
@@ -7,83 +7,75 @@
 [ext_resource path="res://Data/Fonts/FontMedium.tres" type="DynamicFont" id=5]
 [ext_resource path="res://Editor/Docks/RailBuilder/RailBuilder.tscn" type="PackedScene" id=6]
 [ext_resource path="res://Editor/Docks/RailAttachments/RailAttachments.tscn" type="PackedScene" id=7]
-[ext_resource path="res://Editor/Docks/Configuration/Configuration.tscn" type="PackedScene" id=8]
+[ext_resource path="res://Data/UI/blur.tres" type="Material" id=8]
 [ext_resource path="res://Editor/Scripts/EditorHUD.gd" type="Script" id=9]
 [ext_resource path="res://Editor/Modules/AddObjects.gd" type="Script" id=10]
 [ext_resource path="res://Editor/Modules/Content_Selector.tscn" type="PackedScene" id=11]
 [ext_resource path="res://Editor/Modules/building_settings.tscn" type="PackedScene" id=12]
 [ext_resource path="res://Data/UI/styles/button_both.tres" type="Theme" id=13]
+[ext_resource path="res://Editor/Scripts/pause_menu.gd" type="Script" id=14]
 
 [node name="Editor" type="Spatial"]
 script = ExtResource( 2 )
 
 [node name="EditorHUD" type="CanvasLayer" parent="."]
-pause_mode = 2
 script = ExtResource( 9 )
 
-[node name="ShowSettingsButton" type="Button" parent="EditorHUD"]
-anchor_left = 1.0
-anchor_right = 1.0
-margin_left = -102.612
-margin_top = 6.73477
-margin_right = -5.6123
-margin_bottom = 34.7348
+[node name="GlobalMenu" type="VBoxContainer" parent="EditorHUD"]
+margin_left = 4.0
+margin_top = 4.0
+margin_right = 40.0
+margin_bottom = 40.0
+
+[node name="ShowSettingsButton" type="Button" parent="EditorHUD/GlobalMenu"]
+margin_right = 111.0
+margin_bottom = 20.0
 grow_horizontal = 0
 text = "Hide Settings"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="SaveWorldButton" type="Button" parent="EditorHUD"]
-margin_left = 7.0
-margin_top = 6.78179
-margin_right = 90.0
-margin_bottom = 26.7818
+[node name="HSeparator" type="HSeparator" parent="EditorHUD/GlobalMenu"]
+margin_top = 24.0
+margin_right = 111.0
+margin_bottom = 28.0
+
+[node name="TestTrack" type="Button" parent="EditorHUD/GlobalMenu"]
+margin_top = 32.0
+margin_right = 111.0
+margin_bottom = 52.0
+text = "Test Track"
+
+[node name="SaveWorldButton" type="Button" parent="EditorHUD/GlobalMenu"]
+margin_top = 56.0
+margin_right = 111.0
+margin_bottom = 76.0
 text = "Save World"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="ExportTrack" type="Button" parent="EditorHUD"]
-margin_left = 7.49803
-margin_top = 62.2427
-margin_right = 96.498
-margin_bottom = 82.2427
+[node name="ExportTrack" type="Button" parent="EditorHUD/GlobalMenu"]
+margin_top = 80.0
+margin_right = 111.0
+margin_bottom = 100.0
 text = "Export Track"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="JumpToStation" type="Button" parent="EditorHUD"]
-margin_left = 6.60713
-margin_top = 90.087
-margin_right = 95.6071
-margin_bottom = 110.087
+[node name="HSeparator2" type="HSeparator" parent="EditorHUD/GlobalMenu"]
+margin_top = 104.0
+margin_right = 111.0
+margin_bottom = 108.0
+
+[node name="JumpToStation" type="MenuButton" parent="EditorHUD/GlobalMenu"]
+margin_top = 112.0
+margin_right = 111.0
+margin_bottom = 132.0
 text = "Jump To Station"
-__meta__ = {
-"_edit_use_anchors_": false
-}
+flat = false
 
-[node name="ItemList" type="ItemList" parent="EditorHUD/JumpToStation"]
-visible = false
-margin_left = 0.114761
-margin_top = 20.304
-margin_right = 166.115
-margin_bottom = 55.304
-auto_height = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="TestTrack" type="Button" parent="EditorHUD"]
-margin_left = 6.60713
-margin_top = 34.4249
-margin_right = 82.6071
-margin_bottom = 54.4249
-text = "Test Track"
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="ShowConfig" type="Button" parent="EditorHUD/GlobalMenu"]
+margin_top = 136.0
+margin_right = 111.0
+margin_bottom = 156.0
+text = "Show Config"
 
 [node name="Settings" type="Control" parent="EditorHUD"]
 anchor_left = 0.624
@@ -93,26 +85,12 @@ margin_left = -0.200012
 margin_top = 67.0
 margin_right = -7.0
 margin_bottom = -11.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="TabContainer" type="TabContainer" parent="EditorHUD/Settings"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Configuration" parent="EditorHUD/Settings/TabContainer" instance=ExtResource( 8 )]
-anchor_left = 0.0
-margin_left = 4.0
-margin_top = 32.0
-margin_right = -4.0
-margin_bottom = -4.0
 
 [node name="RailBuilder" parent="EditorHUD/Settings/TabContainer" instance=ExtResource( 6 )]
-visible = false
 margin_left = 4.0
 margin_top = 32.0
 margin_right = -4.0
@@ -121,21 +99,21 @@ margin_bottom = -4.0
 [node name="RailLogic" parent="EditorHUD/Settings/TabContainer" instance=ExtResource( 3 )]
 visible = false
 margin_left = 4.0
-margin_top = 32.0
+margin_top = 24.0
 margin_right = -4.0
 margin_bottom = -4.0
 
 [node name="RailAttachments" parent="EditorHUD/Settings/TabContainer" instance=ExtResource( 7 )]
 visible = false
 margin_left = 4.0
-margin_top = 32.0
+margin_top = 24.0
 margin_right = -4.0
 margin_bottom = -4.0
 
 [node name="BuildingSettings" parent="EditorHUD/Settings/TabContainer" instance=ExtResource( 12 )]
 visible = false
 margin_left = 4.0
-margin_top = 32.0
+margin_top = 24.0
 margin_right = -4.0
 margin_bottom = -4.0
 
@@ -337,9 +315,6 @@ margin_top = -29.5459
 margin_right = 41.435
 margin_bottom = -9.5459
 text = " + "
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Menu1" type="ItemList" parent="EditorHUD/AddObjects"]
 visible = false
@@ -420,20 +395,16 @@ __meta__ = {
 }
 
 [node name="Pause" type="Control" parent="EditorHUD"]
+pause_mode = 2
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
+script = ExtResource( 14 )
 
 [node name="ColorRect" type="ColorRect" parent="EditorHUD/Pause"]
+material = ExtResource( 8 )
 anchor_right = 1.0
 anchor_bottom = 1.0
-color = Color( 0, 0, 0, 0.784314 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="VBoxContainer" type="VBoxContainer" parent="EditorHUD/Pause"]
 anchor_left = 0.5
@@ -455,7 +426,7 @@ theme = ExtResource( 13 )
 custom_fonts/font = ExtResource( 5 )
 text = "BACK"
 
-[node name="SaveWithoutExit" type="Button" parent="EditorHUD/Pause/VBoxContainer"]
+[node name="ExitWithoutSave" type="Button" parent="EditorHUD/Pause/VBoxContainer"]
 margin_top = 53.0
 margin_right = 326.0
 margin_bottom = 102.0
@@ -498,12 +469,12 @@ control_path = NodePath("../EditorHUD/Settings")
 [node name="OutlinesPP" parent="." instance=ExtResource( 4 )]
 highlight_color = Color( 1, 1, 0, 1 )
 
-[connection signal="pressed" from="EditorHUD/ShowSettingsButton" to="EditorHUD" method="_on_ShowSettings_pressed"]
-[connection signal="pressed" from="EditorHUD/SaveWorldButton" to="." method="_on_SaveWorldButton_pressed"]
-[connection signal="pressed" from="EditorHUD/ExportTrack" to="." method="_on_ExportTrack_pressed"]
-[connection signal="pressed" from="EditorHUD/JumpToStation" to="EditorHUD" method="_on_JumpToStation_pressed"]
-[connection signal="item_selected" from="EditorHUD/JumpToStation/ItemList" to="EditorHUD" method="_on_JumpToStationItemList_item_selected"]
-[connection signal="pressed" from="EditorHUD/TestTrack" to="." method="_on_TestTrack_pressed"]
+[connection signal="pressed" from="EditorHUD/GlobalMenu/ShowSettingsButton" to="EditorHUD" method="_on_ShowSettings_pressed"]
+[connection signal="pressed" from="EditorHUD/GlobalMenu/TestTrack" to="." method="_on_TestTrack_pressed"]
+[connection signal="pressed" from="EditorHUD/GlobalMenu/SaveWorldButton" to="." method="_on_SaveWorldButton_pressed"]
+[connection signal="pressed" from="EditorHUD/GlobalMenu/ExportTrack" to="." method="_on_ExportTrack_pressed"]
+[connection signal="pressed" from="EditorHUD/GlobalMenu/JumpToStation" to="EditorHUD" method="_on_JumpToStation_pressed"]
+[connection signal="pressed" from="EditorHUD/GlobalMenu/ShowConfig" to="EditorHUD" method="_on_ShowConfig_pressed"]
 [connection signal="text_entered" from="EditorHUD/ObjectName/Name/LineEdit" to="EditorHUD" method="_onObjectName_text_entered"]
 [connection signal="pressed" from="EditorHUD/ObjectName/Name/Clear" to="EditorHUD" method="_on_ClearCurrentObject_pressed"]
 [connection signal="pressed" from="EditorHUD/ObjectName/Name/Rename" to="EditorHUD" method="_on_CurrentObjectRename_pressed"]
@@ -521,6 +492,8 @@ highlight_color = Color( 1, 1, 0, 1 )
 [connection signal="resource_selected" from="EditorHUD/Content_Selector" to="EditorHUD/Settings/TabContainer/BuildingSettings" method="_on_Content_Selector_resource_selected"]
 [connection signal="resource_selected" from="EditorHUD/Content_Selector" to="EditorHUD/AddObjects" method="_on_Content_Selector_resource_selected"]
 [connection signal="pressed" from="EditorHUD/Message/MessageClose" to="." method="_on_MessageClose_pressed"]
-[connection signal="pressed" from="EditorHUD/Pause/VBoxContainer/Back" to="EditorHUD" method="_on_Pause_Back_pressed"]
-[connection signal="pressed" from="EditorHUD/Pause/VBoxContainer/SaveWithoutExit" to="EditorHUD" method="_on_SaveWithoutExit_pressed"]
-[connection signal="pressed" from="EditorHUD/Pause/VBoxContainer/SaveAndExit" to="EditorHUD" method="_on_SaveAndExit_pressed"]
+[connection signal="hide" from="EditorHUD/Pause" to="EditorHUD/Pause" method="_on_hide"]
+[connection signal="save_requested" from="EditorHUD/Pause" to="." method="_on_Pause_save_requested"]
+[connection signal="pressed" from="EditorHUD/Pause/VBoxContainer/Back" to="EditorHUD/Pause" method="_on_Back_pressed"]
+[connection signal="pressed" from="EditorHUD/Pause/VBoxContainer/ExitWithoutSave" to="EditorHUD/Pause" method="_on_ExitWithoutSave_pressed"]
+[connection signal="pressed" from="EditorHUD/Pause/VBoxContainer/SaveAndExit" to="EditorHUD/Pause" method="_on_SaveAndExit_pressed"]

--- a/src/Editor/Scripts/Editor.gd
+++ b/src/Editor/Scripts/Editor.gd
@@ -287,7 +287,7 @@ func provide_settings_for_selected_object() -> void:
 	if selected_object_type == "Rail":
 		$EditorHUD/Settings/TabContainer/RailAttachments.update_selected_rail(selected_object)
 		$EditorHUD/Settings/TabContainer/RailBuilder.update_selected_rail(selected_object)
-		$EditorHUD.ensure_rail_settings()
+		$EditorHUD.show_rail_settings()
 	else:
 		$EditorHUD/Settings/TabContainer/RailAttachments.update_selected_rail(null)
 		$EditorHUD/Settings/TabContainer/RailBuilder.update_selected_rail(null)
@@ -342,7 +342,6 @@ func save_world(send_message: bool = true) -> void:
 			send_message("An error occurred while saving the scene to disk.")
 			return
 
-	$EditorHUD/Settings/TabContainer/Configuration.save_everything()
 	$World.j_save_module.write_to_disk()
 
 	$World.chunk_manager.resume_chunking()
@@ -652,3 +651,7 @@ func get_children_of_type_recursive(node: Node, type) -> Array:
 func set_current_track_path(path: String) -> void:
 	current_track_path = path
 	current_track_name = path.get_file()
+
+
+func _on_Pause_save_requested() -> void:
+	save_world(false)

--- a/src/Editor/Scripts/EditorHUD.gd
+++ b/src/Editor/Scripts/EditorHUD.gd
@@ -1,6 +1,11 @@
 extends CanvasLayer
 
 
+func _ready() -> void:
+	var station_popup: PopupMenu = $GlobalMenu/JumpToStation.get_popup()
+	station_popup.connect("index_pressed", self, "_on_jump_station_pressed")
+
+
 func handle_object_transform_field():
 	$ObjectName/Name/Duplicate.visible = get_parent().selected_object_type == "Building"
 	if not $ObjectTransform.visible:
@@ -14,21 +19,20 @@ func handle_object_transform_field():
 
 
 func _unhandled_input(_event: InputEvent) -> void:
-	if Input.is_action_just_pressed("Escape"):
-		if $Pause.visible:
-			_on_Pause_Back_pressed()
-		else:
-			$Pause.show()
-			get_tree().paused = true
 	handle_object_transform_field()
 
+
+func _unhandled_key_input(_event: InputEventKey) -> void:
+	if Input.is_action_just_released("ui_cancel", true):
+		get_tree().paused = true
+		$Pause.show()
 
 
 func update_ShowSettingsButton():
 	if not $Settings.visible:
-		$ShowSettingsButton.text = "Show Settings"
+		$GlobalMenu/ShowSettingsButton.text = "Show Settings"
 	else:
-		$ShowSettingsButton.text = "Hide Settings"
+		$GlobalMenu/ShowSettingsButton.text = "Hide Settings"
 
 
 func _on_ShowSettings_pressed():
@@ -77,22 +81,6 @@ func _on_DeleteCurrentObject_pressed():
 	get_parent().delete_selected_object()
 
 
-func _on_Pause_Back_pressed():
-	get_tree().paused = false
-	$Pause.hide()
-
-
-func _on_SaveAndExit_pressed():
-	get_parent().save_world()
-	get_tree().paused = false
-	LoadingScreen.load_main_menu()
-
-
-func _on_SaveWithoutExit_pressed():
-	get_tree().paused = false
-	LoadingScreen.load_main_menu()
-
-
 func _on_x_value_changed(value):
 	var selected_object = get_parent().selected_object
 	selected_object.translation.x = value
@@ -118,19 +106,16 @@ func _onObjectName_text_entered(_new_text):
 
 
 func show_building_settings():
-	show_settings()
-	$Settings/TabContainer.current_tab = 4
+	$Settings/TabContainer.current_tab = 3
 
 
 func show_signal_settings():
-	show_settings()
-	$Settings/TabContainer.current_tab = 2
+	$Settings/TabContainer.current_tab = 1
 
 
-func ensure_rail_settings():
-	show_settings()
-	if not $Settings/TabContainer.current_tab == 1 and not $Settings/TabContainer.current_tab == 3:
-		$Settings/TabContainer.current_tab = 1
+func show_rail_settings():
+	if not $Settings/TabContainer.current_tab == 0 and not $Settings/TabContainer.current_tab == 2:
+		$Settings/TabContainer.current_tab = 0
 
 
 func  _on_DuplicateObject_pressed():
@@ -138,19 +123,20 @@ func  _on_DuplicateObject_pressed():
 
 
 func _on_JumpToStation_pressed():
-	if $JumpToStation/ItemList.visible:
-		$JumpToStation/ItemList.hide()
-		return
-	$JumpToStation/ItemList.clear()
-	var station_node_names = get_parent().get_all_station_node_names_in_world()
+	var station_menu: PopupMenu = $GlobalMenu/JumpToStation.get_popup()
+	station_menu.clear()
+	var station_node_names: Array = get_parent().get_all_station_node_names_in_world()
+	station_node_names.sort()
 	for station_node_name in station_node_names:
-		$JumpToStation/ItemList.add_item(station_node_name)
-	$JumpToStation/ItemList.sort_items_by_text()
-	$JumpToStation/ItemList.show()
-	$JumpToStation/ItemList.grab_focus()
+		station_menu.add_item(station_node_name)
 
 
-func _on_JumpToStationItemList_item_selected(index):
-	$JumpToStation/ItemList.hide()
-	get_parent().jump_to_station($JumpToStation/ItemList.get_item_text(index))
+func _on_jump_station_pressed(index: int) -> void:
+	var station_menu: PopupMenu = $GlobalMenu/JumpToStation.get_popup()
+	get_parent().jump_to_station(station_menu.get_item_text(index))
 
+
+func _on_ShowConfig_pressed() -> void:
+	var config: WindowDialog = preload("res://Editor/Docks/Configuration/Configuration.tscn").instance()
+	add_child(config)
+	config.popup_centered()

--- a/src/Editor/Scripts/pause_menu.gd
+++ b/src/Editor/Scripts/pause_menu.gd
@@ -1,0 +1,30 @@
+extends Control
+
+signal save_requested
+
+
+func _unhandled_key_input(event: InputEventKey) -> void:
+	if visible and Input.is_action_just_released("ui_cancel", true):
+		# There seems to be an issue with event propagation
+		# Hence we wait for the frame to end before we actually hide it
+		# because otherwise we immediately open the menu again.
+		call_deferred("hide")
+
+
+func _on_SaveAndExit_pressed():
+	emit_signal("save_requested")
+	get_tree().paused = false
+	LoadingScreen.load_main_menu()
+
+
+func _on_Back_pressed() -> void:
+	hide()
+
+
+func _on_hide() -> void:
+	get_tree().paused = false
+
+
+func _on_ExitWithoutSave_pressed() -> void:
+	get_tree().paused = false
+	LoadingScreen.load_main_menu()

--- a/src/project.godot
+++ b/src/project.godot
@@ -311,8 +311,6 @@ settings/stdout/verbose_stdout=true
 
 [display]
 
-window/size/width="800"
-window/size/height="600"
 window/handheld/orientation="sensor_landscape"
 
 [editor_plugins]


### PR DESCRIPTION
I also made some adjustments to the buttons in the top left (from now on global menu). Most importantly making the jump station button a MenuButton and putting all of these buttons into a container.

The config window is instantiated every time and saves its values when pressing save. Cancel, close, or pressing escape won't save the values.
Speaking of escape... In order to fix escape really working the way we wanna have it working, I had to refactor the menu into its own script. So that's that. I took the chance and replaced `get_parent().get_parent().save_world()` with a signal, too.

Sorry for that huge boy of a commit. I am out of practice :sweat_smile:

Fixes #382