### PR TITLE
Fix: incorrect conversion to radians

### DIFF
--- a/src/Data/Scripts/Rail.gd
+++ b/src/Data/Scripts/Rail.gd
@@ -23,8 +23,8 @@ export (Vector3) var end_pos: Vector3
 
 
 ## Steep
-export (float) var start_slope: float = 0  # Radians
-export (float) var end_slope: float = 0  # Radians
+export (float) var start_slope: float = 0  # % (meters / 100 meters)
+export (float) var end_slope: float = 0  # % (meters / 100 meters)
 
 export (float) var start_tend: float = 0
 export (float) var tend1_pos: float = -1
@@ -199,7 +199,13 @@ func get_global_transform_at_distance(distance: float) -> Transform:
 # local to this rail
 func get_local_transform_at_distance(distance: float) -> Transform:
 	if parallel_rail_name == "":
-		return Transform(Basis().rotated(Vector3(1,0,0), get_tend_at_distance(distance)).rotated(Vector3(0,0,1), get_height_rot(distance)).rotated(Vector3(0,1,0), circle_get_rad(radius, distance)), get_local_pos_at_distance(distance) )
+		return Transform( \
+			Basis() \
+				.rotated(Vector3(1,0,0), get_tend_at_distance(distance)) \
+				.rotated(Vector3(0,0,1), get_height_rot(distance)) \
+				.rotated(Vector3(0,1,0), circle_get_rad(radius, distance)), \
+			 get_local_pos_at_distance(distance) \
+		)
 	else:
 		if parallel_rail == null:
 			update_parallel_rail_settings()
@@ -335,18 +341,19 @@ func get_height_rot(distance: float) -> float: ## Get Slope
 			new_radius = 0
 		var newDistance = distance
 		if radius != 0:
-			newDistance = distance * ((new_radius)/(radius))
+			newDistance = distance * (new_radius / radius)
 		return parallel_rail.get_height_rot(newDistance)
+
 	var start_gradient = atan(start_slope/100)
 	var end_gradient = atan(end_slope/100)
-
 	var basicRot = start_gradient
 	if end_gradient - start_gradient == 0:
 		return basicRot
-	var heightRadius = length/(end_gradient - start_gradient)
+	var heightRadius = length / (end_gradient - start_gradient)
 	return circle_get_rad(heightRadius, distance) + basicRot
 
 
+# I do not understand this calculation, so I will leave it as is and use deg2rad() instead...
 func get_tend_at_distance(distance: float) -> float:
 	if is_instance_valid(parallel_rail):
 		var new_radius: float = radius - distance_to_parallel_rail
@@ -358,15 +365,15 @@ func get_tend_at_distance(distance: float) -> float:
 		return parallel_rail.get_tend_at_distance(newDistance)
 
 	if distance >= tend1_pos and distance < tend2_pos:
-		return -(tend1 + (tend2-tend1) * (distance - tend1_pos)/(tend2_pos - tend1_pos))
+		return deg2rad(-(tend1 + (tend2-tend1) * (distance - tend1_pos)/(tend2_pos - tend1_pos)))
 
 	if distance <= tend1_pos:
-		return -(start_tend + (tend1-start_tend) * (distance)/(tend1_pos))
+		return deg2rad(-(start_tend + (tend1-start_tend) * (distance)/(tend1_pos)))
 
 	if tend2_pos > 0 and distance >= tend2_pos:
-		return -(tend2 + (end_tend-tend2) * (distance -tend2_pos)/(length-tend2_pos))
+		return deg2rad(-(tend2 + (end_tend-tend2) * (distance -tend2_pos)/(length-tend2_pos)))
 
-	return -(start_tend + (end_tend-start_tend) * (distance/length))
+	return deg2rad(-(start_tend + (end_tend-start_tend) * (distance/length)))
 
 
 func get_tendSlopeData() -> Dictionary:

--- a/src/Editor/Docks/RailBuilder/RailBuilder.gd
+++ b/src/Editor/Docks/RailBuilder/RailBuilder.gd
@@ -320,10 +320,10 @@ func _on_ShowHideSlope_pressed() -> void:
 
 func get_tendSlopeData() -> Dictionary:
 	var d := {}
-	d.start_slope = deg2rad($S/Settings/Slope/SlopeGrid/StartSlope.value)
-	d.end_slope = deg2rad($S/Settings/Slope/SlopeGrid/EndSlope.value)
-	d.start_tend = deg2rad($S/Settings/Tendency/S/StartTend.value)
-	d.end_tend = deg2rad($S/Settings/Tendency/S/EndTend.value)
+	d.start_slope = $S/Settings/Slope/SlopeGrid/StartSlope.value
+	d.end_slope = $S/Settings/Slope/SlopeGrid/EndSlope.value
+	d.start_tend = $S/Settings/Tendency/S/StartTend.value
+	d.end_tend = $S/Settings/Tendency/S/EndTend.value
 	d.tend1_pos = $S/Settings/Tendency/S2/Tend1Pos.value
 	d.tend1 = $S/Settings/Tendency/S2/Tend1.value
 	d.tend2_pos = $S/Settings/Tendency/S2/Tend2Pos.value
@@ -334,10 +334,10 @@ func get_tendSlopeData() -> Dictionary:
 
 func set_tendSlopeData(data: Dictionary) -> void:
 	var s := data
-	$S/Settings/Slope/SlopeGrid/StartSlope.value = rad2deg(s.start_slope)
-	$S/Settings/Slope/SlopeGrid/EndSlope.value = rad2deg(s.end_slope)
-	$S/Settings/Tendency/S/StartTend.value = rad2deg(s.start_tend)
-	$S/Settings/Tendency/S/EndTend.value = rad2deg(s.end_tend)
+	$S/Settings/Slope/SlopeGrid/StartSlope.value = s.start_slope
+	$S/Settings/Slope/SlopeGrid/EndSlope.value = s.end_slope
+	$S/Settings/Tendency/S/StartTend.value = s.start_tend
+	$S/Settings/Tendency/S/EndTend.value = s.end_tend
 	$S/Settings/Tendency/S2/Tend1Pos.value = s.tend1_pos
 	$S/Settings/Tendency/S2/Tend1.value = s.tend1
 	$S/Settings/Tendency/S2/Tend2Pos.value = s.tend2_pos


### PR DESCRIPTION
With PR #277, I also converted `slope` and `tend` of the rail into radians, because I had incorrectly identified them as angles.  
This isn't the case, and I have now reverted the conversion, calculations with these values were never changed.  
Sorry for this error.