### PR TITLE
fix angle_distance_rad

### DIFF
--- a/src/Data/Scripts/Singletons/Math.gd
+++ b/src/Data/Scripts/Singletons/Math.gd
@@ -46,9 +46,12 @@ func norm_rad(radians: float) -> float:
 
 # returns the shortest distance in between the 2 rotations in radians
 func angle_distance_rad(rad1: float, rad2: float) -> float:
-	var norm1 = norm_rad(rad1)
-	var norm2 = norm_rad(rad2)
-	return PI - abs(abs(norm1 - norm2) - PI)
+	# https://stackoverflow.com/questions/28036652/finding-the-shortest-distance-between-two-angles
+	# ± PI because we shift to be in [-180, 180] instead of [0, 360]
+	var diff = fmod(rad1 - rad2 + PI, TAU) - PI  # returns an angle in [-540, 180)
+	if diff < -PI:
+		diff += TAU  # fix to [-180, 180)
+	return abs(diff)  # return DISTANCE (-> absolute) between angles
 
 
 # Gets A Dict like {"name": [], "position" : []}, returns the array of the signal


### PR DESCRIPTION
The old calculation for `angle_distance_rad` was wrong. It was not symmetric / commutative.
The new calculation fixes this problem.

The problem I found on U2 Nuremburg:

```
rail1.end_rot = 1.42066
rail2.end_rot = -1.72093
```

connection from rail1 to rail2:
```
angle_distance_rad(1.42066, -1.72093 + PI)
norm1 = 1.42066 ; norm2 = 1.42066
PI - abs(abs(1.42066-1.42066) - PI) = 0

new calc: 
fmod(1.42066 - (-1.72093 +PI) + PI, TAU) - PI = 0
return abs(0) = 0
```


connection from rail2 to rail1:
```
angle_distance_rad(-1.72093, 1.42066 + PI)
norm1 = -1.72093 ; norm2 = 1.42066
PI - abs(abs(-1.72093 - 1.42066) - PI) = PI !!!

new calc: fmod(-1.72093 - (1.42066+PI) + PI, TAU) - PI = -TAU
-TAU < -PI: result+=TAU
return abs(0) = 0
```