### PR TITLE
Fix Gizmo selection and implement mouse position restoring

### DIFF
--- a/src/Editor/Modules/Gizmo.tscn
+++ b/src/Editor/Modules/Gizmo.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://Editor/Scripts/Gizmo.gd" type="Script" id=1]
 
 [sub_resource type="BoxShape" id=1]
-extents = Vector3( 5.5, 0.5, 0.5 )
+extents = Vector3( 4.5, 0.5, 0.5 )
 
 [sub_resource type="CylinderMesh" id=11]
 
@@ -18,7 +18,7 @@ emission_operator = 0
 emission_on_uv2 = false
 
 [sub_resource type="BoxShape" id=4]
-extents = Vector3( 5.5, 0.5, 0.5 )
+extents = Vector3( 4.5, 0.5, 0.5 )
 
 [sub_resource type="CylinderMesh" id=12]
 
@@ -33,7 +33,7 @@ emission_operator = 0
 emission_on_uv2 = false
 
 [sub_resource type="BoxShape" id=6]
-extents = Vector3( 5.5, 0.5, 0.5 )
+extents = Vector3( 4.5, 0.5, 0.5 )
 
 [sub_resource type="CylinderMesh" id=13]
 
@@ -71,25 +71,26 @@ radius = 7.0
 script = ExtResource( 1 )
 
 [node name="x-axis" type="StaticBody" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 0, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 0 )
 
 [node name="CollisionShape" type="CollisionShape" parent="x-axis"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 3, 0, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0 )
 shape = SubResource( 1 )
 
 [node name="MeshInstance2" type="MeshInstance" parent="x-axis"]
-transform = Transform( -2.18557e-08, -4.5, 0, 0.5, -1.96701e-07, 0, 0, 0, 0.5, 2, 0, 0 )
+transform = Transform( -2.18557e-08, -4.5, 0, 0.5, -1.96701e-07, 0, 0, 0, 0.5, 1, 0, 0 )
 mesh = SubResource( 11 )
 material/0 = SubResource( 3 )
 
 [node name="y-axis" type="StaticBody" parent="."]
-transform = Transform( 0.5, 0, 0, 0, 4.5, 0, 0, 0, 0.5, 0, 4, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4, 0 )
 
 [node name="CollisionShape" type="CollisionShape" parent="y-axis"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, 0 )
+transform = Transform( -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0, 1, 0, 1, 0 )
 shape = SubResource( 4 )
 
 [node name="MeshInstance2" type="MeshInstance" parent="y-axis"]
+transform = Transform( 0.5, 0, 0, 0, 4.5, 0, 0, 0, 0.5, 0, 1, 0 )
 mesh = SubResource( 12 )
 material/0 = SubResource( 5 )
 
@@ -97,7 +98,7 @@ material/0 = SubResource( 5 )
 transform = Transform( 4.37114e-08, -3.82137e-15, -1, -8.74228e-08, -1, 0, -1, 8.74228e-08, -4.37114e-08, 0, 0, -4 )
 
 [node name="CollisionShape" type="CollisionShape" parent="z-axis"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0 )
 shape = SubResource( 6 )
 
 [node name="MeshInstance2" type="MeshInstance" parent="z-axis"]

--- a/src/Editor/Scripts/Editor.gd
+++ b/src/Editor/Scripts/Editor.gd
@@ -619,6 +619,10 @@ func _snap_complex_connector(snap_pos: Vector3, snap_rot: float) -> void:
 
 
 func select_object_under_mouse() -> void:
+	# Return early if we currently have an active gizmo
+	if object_has_active_gizmo(selected_object):
+		return
+	
 	var ray_length: float = 1000
 	var mouse_pos: Vector2 = get_viewport().get_mouse_position()
 	var from: Vector3 = camera.project_ray_origin(mouse_pos)
@@ -684,6 +688,19 @@ func get_type_of_object(object: Node) -> String:
 	else:
 		Logger.warn("Unknown object type encountered!", object)
 		return "Unknown"
+
+
+func object_has_active_gizmo(object: Node) -> bool:
+	# Return early if object is null
+	if not is_instance_valid(object):
+		return false
+	
+	# Iterate over children and return true if an ACTIVE gizmo is found
+	for node in object.get_children():
+		if node.is_in_group("Gizmo"):
+			if node.any_axis_active():
+				return true
+	return false
 
 
 func provide_settings_for_selected_object() -> void:

--- a/src/Editor/Scripts/Gizmo.gd
+++ b/src/Editor/Scripts/Gizmo.gd
@@ -4,33 +4,53 @@ extends Spatial
 var x_active = false
 var y_active = false
 var z_active = false
-
 var x_rot_active = false
 
+var x_hovered = false
+var y_hovered = false
+var z_hovered = false
+var x_rot_hovered = false
 
 var mouseMotion = Vector2(0,0)
+
 func _input(event):
 	if event is InputEventMouseMotion:
 		mouseMotion = mouseMotion + event.relative * (-1 if z_active else 1)
 
+	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT:
+		if event.pressed:
+			# Reset mouse motion
+			mouseMotion = Vector2(0,0)
+			
+			# Ensure only one axis is active at a time
+			if x_hovered:
+				x_active = true
+			elif y_hovered:
+				y_active = true
+			elif z_hovered:
+				z_active = true
+			elif x_rot_hovered:
+				x_rot_active = true
 
-	if event is InputEventMouseButton and event.pressed == true:
-		mouseMotion = Vector2(0,0)
+			# Capture mouse
+			if any_axis_active():
+				Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 
-	if event is InputEventMouseButton:
-		if event.pressed == false:
+		elif any_axis_active():
+			# Deactivate all axes
 			x_active = false
 			y_active = false
 			z_active = false
 			x_rot_active = false
+
+			# Release mouse
 			Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 
 
 func _process(_delta):
 	rotation.y = - get_parent().rotation.y
 
-	if Input.is_mouse_button_pressed(BUTTON_LEFT) and (x_active or y_active or z_active or x_rot_active):
-		Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+	if Input.is_mouse_button_pressed(BUTTON_LEFT) and any_axis_active():
 		if x_active:
 			get_parent().translation.x += mouseMotion.x * 0.01
 		if y_active:
@@ -44,37 +64,33 @@ func _process(_delta):
 		mouseMotion = Vector2(0,0)
 
 
+func any_axis_active():
+	return x_active or y_active or z_active or x_rot_active
+
 
 func _on_xaxis_mouse_entered():
-	x_active = true
+	x_hovered = true
 
 func _on_xaxis_mouse_exited():
-	if not Input.is_mouse_button_pressed(BUTTON_LEFT):
-		x_active = false
+	x_hovered = false
 
 
 func _on_yaxis_mouse_entered():
-	y_active = true
-
+	y_hovered = true
 
 func _on_yaxis_mouse_exited():
-	if not Input.is_mouse_button_pressed(BUTTON_LEFT):
-		y_active = false
+	y_hovered = false
 
 
 func _on_zaxis_mouse_entered():
-	z_active = true
-
+	z_hovered = true
 
 func _on_zaxis_mouse_exited():
-	if not Input.is_mouse_button_pressed(BUTTON_LEFT):
-		z_active = false
+	z_hovered = false
 
 
 func _on_x_rot_mouse_entered():
-	x_rot_active = true
-
+	x_rot_hovered = true
 
 func _on_x_rot_mouse_exited():
-	if not Input.is_mouse_button_pressed(BUTTON_LEFT):
-		x_rot_active = false
+	x_rot_hovered = false

--- a/src/Editor/Scripts/Gizmo.gd
+++ b/src/Editor/Scripts/Gizmo.gd
@@ -1,23 +1,23 @@
 extends Spatial
 
 
-var x_active = false
-var y_active = false
-var z_active = false
-var x_rot_active = false
+var x_active := false
+var y_active := false
+var z_active := false
+var x_rot_active := false
 
-var x_hovered = false
-var y_hovered = false
-var z_hovered = false
-var x_rot_hovered = false
+var x_hovered := false
+var y_hovered := false
+var z_hovered := false
+var x_rot_hovered := false
 
-var mouse_position_before_capture = null
+var mouse_position_before_capture := Vector2(0,0)
 
-var mouseMotion = Vector2(0,0)
+var mouseMotion := Vector2(0,0)
 
 func _input(event):
 	if event is InputEventMouseMotion:
-		mouseMotion = mouseMotion + event.relative * (-1 if z_active else 1)
+		mouseMotion += event.relative * (-1 if z_active else 1)
 
 	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT:
 		if event.pressed:
@@ -68,33 +68,33 @@ func _process(_delta):
 		mouseMotion = Vector2(0,0)
 
 
-func any_axis_active():
+func any_axis_active() -> bool:
 	return x_active or y_active or z_active or x_rot_active
 
 
-func _on_xaxis_mouse_entered():
+func _on_xaxis_mouse_entered() -> void:
 	x_hovered = true
 
-func _on_xaxis_mouse_exited():
+func _on_xaxis_mouse_exited() -> void:
 	x_hovered = false
 
 
-func _on_yaxis_mouse_entered():
+func _on_yaxis_mouse_entered() -> void:
 	y_hovered = true
 
-func _on_yaxis_mouse_exited():
+func _on_yaxis_mouse_exited() -> void:
 	y_hovered = false
 
 
-func _on_zaxis_mouse_entered():
+func _on_zaxis_mouse_entered() -> void:
 	z_hovered = true
 
-func _on_zaxis_mouse_exited():
+func _on_zaxis_mouse_exited() -> void:
 	z_hovered = false
 
 
-func _on_x_rot_mouse_entered():
+func _on_x_rot_mouse_entered() -> void:
 	x_rot_hovered = true
 
-func _on_x_rot_mouse_exited():
+func _on_x_rot_mouse_exited() -> void:
 	x_rot_hovered = false

--- a/src/Editor/Scripts/Gizmo.gd
+++ b/src/Editor/Scripts/Gizmo.gd
@@ -11,6 +11,8 @@ var y_hovered = false
 var z_hovered = false
 var x_rot_hovered = false
 
+var mouse_position_before_capture = null
+
 var mouseMotion = Vector2(0,0)
 
 func _input(event):
@@ -21,7 +23,7 @@ func _input(event):
 		if event.pressed:
 			# Reset mouse motion
 			mouseMotion = Vector2(0,0)
-			
+
 			# Ensure only one axis is active at a time
 			if x_hovered:
 				x_active = true
@@ -34,6 +36,7 @@ func _input(event):
 
 			# Capture mouse
 			if any_axis_active():
+				mouse_position_before_capture = get_viewport().get_mouse_position()
 				Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 
 		elif any_axis_active():
@@ -45,6 +48,7 @@ func _input(event):
 
 			# Release mouse
 			Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+			get_viewport().warp_mouse(mouse_position_before_capture)
 
 
 func _process(_delta):


### PR DESCRIPTION
Some improvements/fixes for the Gizmo:

- Fixes the collision shapes and axis positioning in `Gizmo.tscn`.
- Fixes the Gizmo's `x_active` (etc.) logic, as it was *very* broken before, especially when dragging outside of the axis collision shapes. We now store corresponding `x_hovered` (etc.) states and use these to determine active states. Look at the code for more details, but basically I did some refactoring.
- Save and restore the mouse position before and after mouse capture (Fixes #416).