### PR TITLE
Rework developer user settings fix

### DIFF
--- a/src/Data/Scripts/Singletons/Root.gd
+++ b/src/Data/Scripts/Singletons/Root.gd
@@ -150,10 +150,6 @@ func get_subfolders_of(directory_path: String) -> Array:
 	return folder_names
 
 
-func set_fullscreen(value: bool) -> void:
-	OS.window_fullscreen = value
-
-
 func set_low_resolution(value: bool) -> void:
 	if value:
 		if ProjectSettings.get_setting("display/window/stretch/mode") == "viewport":
@@ -165,7 +161,7 @@ func set_low_resolution(value: bool) -> void:
 	else:
 		ProjectSettings.set_setting("display/window/stretch/mode", "disabled")
 		ProjectSettings.set_setting("display/window/stretch/aspect", "ignore")
-		ProjectSettings.set_setting("display/window/size/width", "800")
+		ProjectSettings.set_setting("display/window/size/width", "1024")
 		ProjectSettings.set_setting("display/window/size/height", "600")
 
 

--- a/src/Data/Scripts/Singletons/Root.gd
+++ b/src/Data/Scripts/Singletons/Root.gd
@@ -150,6 +150,10 @@ func get_subfolders_of(directory_path: String) -> Array:
 	return folder_names
 
 
+func set_fullscreen(value: bool) -> void:
+	OS.window_fullscreen = value
+
+
 func set_low_resolution(value: bool) -> void:
 	if value:
 		if ProjectSettings.get_setting("display/window/stretch/mode") == "viewport":
@@ -161,7 +165,7 @@ func set_low_resolution(value: bool) -> void:
 	else:
 		ProjectSettings.set_setting("display/window/stretch/mode", "disabled")
 		ProjectSettings.set_setting("display/window/stretch/aspect", "ignore")
-		ProjectSettings.set_setting("display/window/size/width", "1024")
+		ProjectSettings.set_setting("display/window/size/width", "800")
 		ProjectSettings.set_setting("display/window/size/height", "600")
 
 

--- a/src/addons/jean28518.jTools/jSettings/JSettings.gd
+++ b/src/addons/jean28518.jTools/jSettings/JSettings.gd
@@ -12,11 +12,11 @@ func popup():
 func _ready():
 	if get_parent().name == "root":
 		$JSettings.hide()
-	
+
 	# Localize the Reset Dialog
 	$"%ResetConfirmationDialog".get_cancel().text = "NO"
 	$"%ResetConfirmationDialog".get_ok().text = "YES"
-	
+
 	first_run_check()
 	apply_saved_settings()
 
@@ -24,7 +24,7 @@ func _ready():
 func first_run_check():
 	# Check if this is the first run, and if it is, apply default settings
 	var dir = Directory.new()
-	if not dir.file_exists("user://override.cfg") or OS.has_feature("editor"):
+	if not dir.file_exists("user://override.cfg") and not OS.has_feature("editor"):
 		Logger.log("First run (\"user://override.cfg\" doesn't exist). Applying default settings.")
 		reset_settings_to_default()
 
@@ -57,33 +57,34 @@ func apply_saved_settings():
 
 func save_settings():
 	# Save, except if in Godot Editor
-	if not OS.has_feature("editor"):
-		var err := ProjectSettings.save_custom("user://override.cfg")
-		if err != OK:
-			Logger.err("Failed to save user settings", self)
-			# Nothing was saved, so nothing needs special treatment
-			return
-		# _global_script_classes gets saved, too
-		# ...
-		# and overriden on load ...
-		# Meaning, any new class that we register in an update will not work causing a crash
-		# this IS a Godot bug, but until I have time to fix it, let's just work around
-		# https://github.com/godotengine/godot/issues/61556 may be intersting as well
-		var file := ConfigFile.new()
-		err = file.load("user://override.cfg")
-		if err != OK:
-			Logger.err("Couldn't load user://override.cfg for _global_script_classes" + \
-					"stripping. This is a major functionality threat! " + \
-					"Please ensure removal of the file!", self)
-			return
-		file.erase_section_key("", "_global_script_classes")
-		file.erase_section_key("", "_global_script_class_icons")
-		err = file.save("user://override.cfg")
-		if err != OK:
-			Logger.err("Couldn't load user://override.cfg for _global_script_classes" + \
-					"stripping. This is a major functionality threat! " + \
-					"Please ensure removal of the file!", self)
-			return
+	if OS.has_feature("editor"):
+		return
+	var err := ProjectSettings.save_custom("user://override.cfg")
+	if err != OK:
+		Logger.err("Failed to save user settings", self)
+		# Nothing was saved, so nothing needs special treatment
+		return
+	# _global_script_classes gets saved, too
+	# ...
+	# and overriden on load ...
+	# Meaning, any new class that we register in an update will not work causing a crash
+	# this IS a Godot bug, but until I have time to fix it, let's just work around
+	# https://github.com/godotengine/godot/issues/61556 may be intersting as well
+	var file := ConfigFile.new()
+	err = file.load("user://override.cfg")
+	if err != OK:
+		Logger.err("Couldn't load user://override.cfg for _global_script_classes" + \
+				"stripping. This is a major functionality threat! " + \
+				"Please ensure removal of the file!", self)
+		return
+	file.erase_section_key("", "_global_script_classes")
+	file.erase_section_key("", "_global_script_class_icons")
+	err = file.save("user://override.cfg")
+	if err != OK:
+		Logger.err("Couldn't load user://override.cfg for _global_script_classes" + \
+				"stripping. This is a major functionality threat! " + \
+				"Please ensure removal of the file!", self)
+		return
 
 
 

--- a/src/addons/jean28518.jTools/jSettings/JSettings.gd
+++ b/src/addons/jean28518.jTools/jSettings/JSettings.gd
@@ -12,11 +12,11 @@ func popup():
 func _ready():
 	if get_parent().name == "root":
 		$JSettings.hide()
-
+	
 	# Localize the Reset Dialog
 	$"%ResetConfirmationDialog".get_cancel().text = "NO"
 	$"%ResetConfirmationDialog".get_ok().text = "YES"
-
+	
 	first_run_check()
 	apply_saved_settings()
 
@@ -24,8 +24,7 @@ func _ready():
 func first_run_check():
 	# Check if this is the first run, and if it is, apply default settings
 	var dir = Directory.new()
-	if (not dir.file_exists("user://override.cfg") and not OS.has_feature("editor")) \
-			or (OS.has_feature("editor") and not dir.file_exists("user://dev.override.cfg")):
+	if not dir.file_exists("user://override.cfg") or OS.has_feature("editor"):
 		Logger.log("First run (\"user://override.cfg\" doesn't exist). Applying default settings.")
 		reset_settings_to_default()
 
@@ -58,34 +57,33 @@ func apply_saved_settings():
 
 func save_settings():
 	# Save, except if in Godot Editor
-	var settings_path := "user://dev.override.cfg" if OS.has_feature("editor") \
-			else "user://override.cfg"
-	var err := ProjectSettings.save_custom(settings_path)
-	if err != OK:
-		Logger.err("Failed to save user settings (%d)" % err, self)
-		# Nothing was saved, so nothing needs special treatment
-		return
-	# _global_script_classes gets saved, too
-	# ...
-	# and overriden on load ...
-	# Meaning, any new class that we register in an update will not work causing a crash
-	# this IS a Godot bug, but until I have time to fix it, let's just work around
-	# https://github.com/godotengine/godot/issues/61556 may be intersting as well
-	var file := ConfigFile.new()
-	err = file.load(settings_path)
-	if err != OK:
-		Logger.err("Couldn't load %s for _global_script_classes" + \
-				"stripping. This is a major functionality threat! " + \
-				"Please ensure removal of the file!" % settings_path, self)
-		return
-	file.erase_section_key("", "_global_script_classes")
-	file.erase_section_key("", "_global_script_class_icons")
-	err = file.save(settings_path)
-	if err != OK:
-		Logger.err("Couldn't load %s for _global_script_classes" + \
-				"stripping. This is a major functionality threat! " + \
-				"Please ensure removal of the file!" % settings_path, self)
-		return
+	if not OS.has_feature("editor"):
+		var err := ProjectSettings.save_custom("user://override.cfg")
+		if err != OK:
+			Logger.err("Failed to save user settings", self)
+			# Nothing was saved, so nothing needs special treatment
+			return
+		# _global_script_classes gets saved, too
+		# ...
+		# and overriden on load ...
+		# Meaning, any new class that we register in an update will not work causing a crash
+		# this IS a Godot bug, but until I have time to fix it, let's just work around
+		# https://github.com/godotengine/godot/issues/61556 may be intersting as well
+		var file := ConfigFile.new()
+		err = file.load("user://override.cfg")
+		if err != OK:
+			Logger.err("Couldn't load user://override.cfg for _global_script_classes" + \
+					"stripping. This is a major functionality threat! " + \
+					"Please ensure removal of the file!", self)
+			return
+		file.erase_section_key("", "_global_script_classes")
+		file.erase_section_key("", "_global_script_class_icons")
+		err = file.save("user://override.cfg")
+		if err != OK:
+			Logger.err("Couldn't load user://override.cfg for _global_script_classes" + \
+					"stripping. This is a major functionality threat! " + \
+					"Please ensure removal of the file!", self)
+			return
 
 
 

--- a/src/project.godot
+++ b/src/project.godot
@@ -409,7 +409,7 @@ boot_splash/fullsize=false
 boot_splash/bg_color=Color( 0.65098, 0.65098, 0.65098, 1 )
 config/icon="res://Data/Misc/logos/lts_logo_16.png"
 config/quit_on_go_back=false
-config/project_settings_override.editor="user://dev.override.cfg"
+config/project_settings_override.editor="user://override_dev.cfg"
 
 [audio]
 
@@ -463,7 +463,6 @@ gameplay/pzb_enabled=true
 gameplay/chunk_unload_distance=2
 gameplay/load_all_chunks=false
 graphics/enable_dynamic_lights=false
-audio/music_volume.editor=0.0
 debug/editor_save_thumbnails=true
 debug/editor_save_thumbnails.release=false
 debug/display_chunk=true
@@ -768,7 +767,6 @@ locale_filter=[ 0, [ "bg", "de", "en", "es", "fr", "it", "ja", "uk" ] ]
 translation_remaps={
 }
 overwritten_language=""
-overwritten_language.editor="en"
 
 [rendering]
 

--- a/src/project.godot
+++ b/src/project.godot
@@ -409,7 +409,7 @@ boot_splash/fullsize=false
 boot_splash/bg_color=Color( 0.65098, 0.65098, 0.65098, 1 )
 config/icon="res://Data/Misc/logos/lts_logo_16.png"
 config/quit_on_go_back=false
-config/project_settings_override.editor="user://override_dev.cfg"
+config/project_settings_override.editor="user://override_hack.cfg"
 
 [audio]
 
@@ -438,6 +438,7 @@ settings/stdout/verbose_stdout=true
 [display]
 
 window/handheld/orientation="sensor_landscape"
+window/size/fullscreen.editor=false
 
 [editor]
 
@@ -463,6 +464,7 @@ gameplay/pzb_enabled=true
 gameplay/chunk_unload_distance=2
 gameplay/load_all_chunks=false
 graphics/enable_dynamic_lights=false
+audio/music_volume.editor=0.0
 debug/editor_save_thumbnails=true
 debug/editor_save_thumbnails.release=false
 debug/display_chunk=true
@@ -767,6 +769,11 @@ locale_filter=[ 0, [ "bg", "de", "en", "es", "fr", "it", "ja", "uk" ] ]
 translation_remaps={
 }
 overwritten_language=""
+overwritten_language.editor="en"
+
+[network]
+
+limits/debugger_stdout/max_chars_per_second=65536
 
 [rendering]
 


### PR DESCRIPTION
My previous fix reintroduced the infamous project settings propagation. I reverted the commit and recommitted the salvagable parts while improving the editor overrides a little bit.