### PR TITLE
Fix pause behaviour

### DIFF
--- a/src/Data/Scripts/Camera.gd
+++ b/src/Data/Scripts/Camera.gd
@@ -67,7 +67,7 @@ func _input(event) -> void:
 
 
 func _process(delta: float) -> void:
-	if get_tree().paused and not Root.ingame_pause:
+	if get_tree().paused and not (Root.game_pause["ingame_pause"] and Root.game_pause.values().count(true) == 1):
 		return
 	if not current:
 		pass

--- a/src/Data/Scripts/Player.gd
+++ b/src/Data/Scripts/Player.gd
@@ -294,7 +294,7 @@ func processLong(delta: float) -> void: ## All functions in it are called every 
 
 var processLongTimer: float = 0
 func _process(delta: float):
-	if get_tree().paused and not Root.ingame_pause:
+	if get_tree().paused and not (Root.game_pause["ingame_pause"] and Root.game_pause.values().count(true) == 1):
 		return
 
 	if world == null:
@@ -400,7 +400,7 @@ func stopEngine() -> void:
 func _unhandled_input(event) -> void:
 	if ai:
 		return
-	if get_tree().paused and not Root.ingame_pause:
+	if get_tree().paused and not (Root.game_pause["ingame_pause"] and Root.game_pause.values().count(true) == 1):
 		return
 	if event is InputEventMouseMotion:
 		mouseMotion = mouseMotion + event.relative

--- a/src/Data/Scripts/Singletons/Root.gd
+++ b/src/Data/Scripts/Singletons/Root.gd
@@ -12,7 +12,7 @@ var mobile_version: bool = OS.has_feature("mobile")
 
 var start_menu_in_play_menu: bool = false
 
-var ingame_pause: bool = false
+var game_pause = {"pause_menu": false, "ingame_pause": false, "message": false}
 
 var world: Node  ## Reference to world
 
@@ -32,17 +32,24 @@ func _ready() -> void:
 func _unhandled_key_input(_event) -> void:
 	if Engine.is_editor_hint():
 		return
-	if Input.is_action_just_pressed("ingame_pause"):
-		if not Root.Editor and not Engine.is_editor_hint():
-			if ingame_pause:
-				get_tree().paused = false
-				ingame_pause = false
-			else:
-				get_tree().paused = true
-				ingame_pause = true
-				jEssentials.show_message(tr("PAUSE_MODE_ENABLED"))
 	if Input.is_action_just_released("fullscreen"):
 		jSettings.set_fullscreen(!OS.window_fullscreen)
+
+
+func set_game_pause(type, value) -> void:
+	game_pause[type] = value
+	update_pause()
+
+func reset_game_pause() -> void:
+	for key in game_pause.keys():
+		game_pause[key] = false
+	update_pause()
+
+func update_pause() -> void:
+	if game_pause.values().has(true):
+		get_tree().paused = true
+	else:
+		get_tree().paused = false
 
 
 ## Get appropriate name for new object. Used for adding and renaming nodes at ingame editor, also for train spawn

--- a/src/Data/UI/HUD.tscn
+++ b/src/Data/UI/HUD.tscn
@@ -326,6 +326,9 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="TextBox" parent="." instance=ExtResource( 3 )]
+visible = false
+
 [node name="Pause" parent="." instance=ExtResource( 1 )]
 visible = false
 focus_mode = 2
@@ -360,9 +363,6 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="TextBox" parent="." instance=ExtResource( 3 )]
-visible = false
-
+[connection signal="closed" from="TextBox" to="." method="_on_TextBox_closed"]
 [connection signal="paused" from="Pause" to="." method="_on_paused"]
 [connection signal="unpaused" from="Pause" to="." method="_on_unpaused"]
-[connection signal="closed" from="TextBox" to="." method="_on_TextBox_closed"]

--- a/src/Data/UI/loading_screen.gd
+++ b/src/Data/UI/loading_screen.gd
@@ -29,7 +29,7 @@ func load_main_menu():
 	get_tree().current_scene.queue_free()
 	get_tree().current_scene = self
 	set_process(true)
-	get_tree().paused = false
+	Root.reset_game_pause();
 	jAudioManager.clear_all_sounds()
 	jEssentials.remove_all_pending_delayed_calls()
 	$ProgressBar/Bar.max_value = loader.get_stage_count()

--- a/src/Data/UI/pause.gd
+++ b/src/Data/UI/pause.gd
@@ -12,26 +12,34 @@ var player: LTSPlayer
 
 func _unhandled_input(_event) -> void:
 	if Input.is_action_just_pressed("Escape"):
-		get_tree().paused = !get_tree().paused
-		visible = !visible
 		if visible:
-			_saved_ingame_pause = Root.ingame_pause
-			Root.ingame_pause = false
-			_saved_mouse_mode = Input.get_mouse_mode()
-			Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-			emit_signal("paused")
+			unpause()
 		else:
-			Input.set_mouse_mode(_saved_mouse_mode)
-			Root.ingame_pause = _saved_ingame_pause
-			emit_signal("unpaused")
+			pause()
+	if Input.is_action_just_pressed("ingame_pause"):
+		if Root.game_pause["ingame_pause"] and Root.game_pause.values().count(true) == 1:
+			Root.set_game_pause("ingame_pause", false)
+		elif not get_tree().paused:
+			Root.set_game_pause("ingame_pause", true)
+			jEssentials.show_message(tr("PAUSE_MODE_ENABLED"))
+
+
+func pause():
+	Root.set_game_pause("pause_menu", true)
+	visible = true
+	_saved_mouse_mode = Input.get_mouse_mode()
+	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+	emit_signal("paused")
+
+func unpause():
+	Root.set_game_pause("pause_menu", false)
+	visible = false
+	Input.set_mouse_mode(_saved_mouse_mode)
+	emit_signal("unpaused")
 
 
 func _on_Back_pressed() -> void:
-	get_tree().paused = false
-	visible = false
-	Input.set_mouse_mode(_saved_mouse_mode)
-	Root.ingame_pause = _saved_ingame_pause
-	emit_signal("unpaused")
+	unpause()
 
 
 func _on_Quit_pressed() -> void:
@@ -39,7 +47,6 @@ func _on_Quit_pressed() -> void:
 
 
 func _on_QuitMenu_pressed() -> void:
-	get_tree().paused = false
 	jAudioManager.clear_all_sounds()
 	jEssentials.remove_all_pending_delayed_calls()
 	LoadingScreen.load_main_menu()

--- a/src/Data/UI/text_box.gd
+++ b/src/Data/UI/text_box.gd
@@ -17,12 +17,12 @@ func message(text: String) -> void:
 	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 	$MarginContainer/VBoxContainer/Message.text = text
 	visible = true
-	get_tree().paused = true
+	Root.set_game_pause("message", true)
 	$MarginContainer/VBoxContainer/Ok.grab_click_focus()
 
 
 func _on_Ok_pressed():
 	visible = false
-	get_tree().paused = false
+	Root.set_game_pause("message", false)
 	Input.set_mouse_mode(_previous_mouse_mode)
 	emit_signal("closed")


### PR DESCRIPTION
This fixes some bugs that occur when combining different methods to pause the game:

- When the pause menu is open and you close a message or toggle ingame pause, the game is running in pause menu and paused when the pause menu is closed.
- You can toggle ingame pause when the pause menu is open. That allows some functions (like the reverser) when activating ingame pause and unpauses the game when deactivating ingame pause.