### PR TITLE
Fix loader crashing if loading count is wrong

### DIFF
--- a/src/Data/UI/loading_screen.gd
+++ b/src/Data/UI/loading_screen.gd
@@ -139,7 +139,8 @@ func _clear() -> void:
 
 
 func update_progress_bar() -> void:
-	$ProgressBar/Bar.value = loader.get_stage()
+	var stage := min(loader.get_stage(), loader.get_stage_count() - 1)
+	$ProgressBar/Bar.value = stage
 	$ProgressBar/Description.text = descriptions[\
-			int(round(loader.get_stage() * (descriptions.size() - 1) \
+			int(round(stage * (descriptions.size() - 1) \
 					/ float(loader.get_stage_count() - 1)))]


### PR DESCRIPTION
I found that bug while I converted the built-in worlds and manually readded resources that were deleted. I didn't change the load_steps at the top and thus it went wrong.