### PR TITLE
Add CI-able build version

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -5,209 +5,256 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ci-${{github.ref}}-test
+  cancel-in-progress: true
+
 env:
-  GODOT_VERSION: 3.5
+  GODOT_VERSION: 3.5.1
   EXPORT_NAME: Libre_TrainSim
 
 jobs:
-# TODO: Use native export platforms and add code sign/adhoc notarization
   export-windows:
-    name: Windows Export (Release)
-    runs-on: ubuntu-latest
-    container:
-      image: barichello/godot-ci:3.5
+    if: false # Disabled because @HaSa can't wrap his head around Godot not wanting to properly start and terminate.
+    name: Windows Exports
+    runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Load Cache
-        uses: actions/cache@v2
+        uses: actions/checkout@v3
+
+      - name: Load Import Folder
+        uses: actions/cache/restore@v3
         with:
           path: src/.import
-          key: ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          enableCrossOsArchive: true
+          key: Import-Windows-${{hashFiles('src/.import')}}
           restore-keys: |
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}
-            ${{github.job}}-${{env.BASE_BRANCH}}
-        continue-on-error: true
-      - name: Setup
+            Import-Windows-${{hashFiles('src/.import')}}
+            Import-Windows-
+            Import-
+      
+      - name: Download Godot
+        run: Invoke-WebRequest -o ../Godot_v${{env.GODOT_VERSION}}-stable_win64.exe.zip  https://github.com/godotengine/godot/releases/download/${{env.GODOT_VERSION}}-stable/Godot_v${{env.GODOT_VERSION}}-stable_win64.exe.zip
+      
+      - name: Extract Godot
+        run: 7z e ../Godot_v${{env.GODOT_VERSION}}-stable_win64.exe.zip -o".."
+      
+      - name: Create Export Template Directory
+        run: mkdir "$env:appdata/godot/templates/"
+      
+      - name: Get Export Templates from Cache
+        id: export-templates-cache
+        uses: actions/cache@v3
+        with:
+          path: ../Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz
+          key: Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz
+
+      - name: Download Godot Release Templates
+        if: steps.export-templates-cache.outputs.cache-hit != 'true'
+        run: Invoke-WebRequest -o ../Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz https://github.com/godotengine/godot/releases/download/${{env.GODOT_VERSION}}-stable/Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz
+
+      - name: Extract and Install Templates
         run: |
-          mkdir -v -p ~/.local/share/godot/templates
-          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
-      - name: Windows Build
+          7z e ../Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz -o"$env:appdata/godot/templates/${{env.GODOT_VERSION}}.stable"
+          dir "$env:appdata/godot/templates/${{env.GODOT_VERSION}}.stable"
+      
+      - name: Create Build Folders
         run: |
-          mkdir -v -p build/windows
-          cd src
-          godot -v --export "Windows Desktop" ../build/windows/$EXPORT_NAME.exe
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+          mkdir build/windows
+          mkdir build/windows-debug
+
+      # Export for Windows Release
+
+      - name: Export Windows Release
+        shell: bash
+        run: ../Godot_v${{env.GODOT_VERSION}}-stable_win64.exe src/project.godot -v --export "Windows Desktop" ../build/windows/${EXPORT_NAME}.exe
+      
+      - name: Upload Windows Release
+        uses: actions/upload-artifact@v3
         with:
           name: windows
           path: build/windows
-  
-  export-windows-debug:
-    name: Windows Export (Debug)
-    runs-on: ubuntu-latest
-    container:
-      image: barichello/godot-ci:3.5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Load Cache
-        uses: actions/cache@v2
-        with:
-          path: src/.import
-          key: ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-          restore-keys: |
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}
-            ${{github.job}}-${{env.BASE_BRANCH}}
-        continue-on-error: true
-      - name: Setup
-        run: |
-          mkdir -v -p ~/.local/share/godot/templates
-          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
-      - name: Windows Build
-        run: |
-          mkdir -v -p build/windows-debug
-          cd src
-          godot -v --export-debug "Windows Desktop" ../build/windows-debug/${EXPORT_NAME}_debug.exe
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+      
+      # Export for Windows Debug
+
+      - name: Export Windows Debug
+        run: Start-Process ../Godot_v${{env.GODOT_VERSION}}-stable_win64.exe -ArgumentList 'src/project.godot -v --export-debug "Windows Desktop" ../build/windows-debug/${EXPORT_NAME}_debug.exe' -Wait -NoNewWindow -PassThru
+      
+      - name: Upload Windows Debug
+        uses: actions/upload-artifact@v3
         with:
           name: windows-debug
-          path: build/windows-debug
-
-  export-linux:
-    name: Linux Export (Release)
-    runs-on: ubuntu-latest
-    container:
-      image: barichello/godot-ci:3.5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Load Cache
-        uses: actions/cache@v2
+          path: build/linux-windows
+      
+      - name: Store Import Folder
+        uses: actions/cache/save@v3
         with:
           path: src/.import
-          key: ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          enableCrossOsArchive: true
+          key: Import-Windows-${{hashFiles('src/.import')}}
+
+  export-linux:
+    # On Linux the import cache is just partially loaded for some weird reason. Probably due the headless build.
+    name: Linux Exports
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Load Import Folder
+        uses: actions/cache/restore@v3
+        with:
+          path: src/.import
+          enableCrossOsArchive: true
+          key: Import-Linux-${{hashFiles('src/.import')}}
           restore-keys: |
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}
-            ${{github.job}}-${{env.BASE_BRANCH}}
-        continue-on-error: true
-      - name: Setup
+            Import-Linux-${{hashFiles('src/.import')}}
+            Import-Linux-
+            Import-
+      
+      - name: Download Godot
+        run: curl -L -o ../Godot_v${{env.GODOT_VERSION}}-stable_linux_headless.64.zip https://github.com/godotengine/godot/releases/download/${{env.GODOT_VERSION}}-stable/Godot_v${{env.GODOT_VERSION}}-stable_linux_headless.64.zip
+      
+      - name: Extract Godot
         run: |
-          mkdir -v -p ~/.local/share/godot/templates
-          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
-      - name: Linux Build
+          unzip -d .. ../Godot_v${{env.GODOT_VERSION}}-stable_linux_headless.64.zip
+          ls -la ..
+      
+      - name: Create Export Template Directory
+        run: mkdir -v -p "${HOME}/.local/share/godot/templates/${{env.GODOT_VERSION}}.stable"
+
+      - name: Download Godot Release Templates
+        run: curl -L -o ../Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz https://github.com/godotengine/godot/releases/download/${{env.GODOT_VERSION}}-stable/Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz
+
+      - name: Extract and Install Templates
+        run: |
+
+          unzip -j -d "${HOME}/.local/share/godot/templates/${{env.GODOT_VERSION}}.stable" ../Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz
+          ls -la "${HOME}/.local/share/godot/templates/${{env.GODOT_VERSION}}.stable"
+      
+      - name: Create Build Folders
         run: |
           mkdir -v -p build/linux
-          cd src
-          godot -v --export "Linux64" ../build/linux/$EXPORT_NAME.x86_64
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+          mkdir -v -p build/linux-debug
+
+      - name: Export Linux Release
+        run: ../Godot_v${{env.GODOT_VERSION}}-stable_linux_headless.64 src/project.godot -v --export "Linux64" ../build/linux/${EXPORT_NAME}.x86_64
+      
+      - name: Upload Linux Release
+        uses: actions/upload-artifact@v3
         with:
           name: linux
           path: build/linux
 
-  export-linux-debug:
-    name: Linux Export (Debug)
-    runs-on: ubuntu-latest
-    container:
-      image: barichello/godot-ci:3.5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Load Cache
-        uses: actions/cache@v2
-        with:
-          path: src/.import
-          key: ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-          restore-keys: |
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}
-            ${{github.job}}-${{env.BASE_BRANCH}}
-        continue-on-error: true
-      - name: Setup
-        run: |
-          mkdir -v -p ~/.local/share/godot/templates
-          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
-      - name: Linux Build
-        run: |
-          mkdir -v -p build/linux-debug
-          cd src
-          godot -v --export-debug "Linux64" ../build/linux-debug/${EXPORT_NAME}_debug.x86_64
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+      - name: Export Linux Debug
+        run: ../Godot_v${{env.GODOT_VERSION}}-stable_linux_headless.64 src/project.godot -v --export-debug "Linux64" ../build/linux-debug/${EXPORT_NAME}_debug.x86_64
+      
+      - name: Upload Linux Debug
+        uses: actions/upload-artifact@v3
         with:
           name: linux-debug
           path: build/linux-debug
-
-  export-mac:
-    name: Mac Export (Release)
-    runs-on: ubuntu-latest
-    container:
-      image: barichello/godot-ci:3.5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Load Cache
-        uses: actions/cache@v2
+      
+      - name: Store Import Folder
+        uses: actions/cache/save@v3
         with:
           path: src/.import
-          key: ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          enableCrossOsArchive: true
+          key: Import-Linux-${{hashFiles('src/.import')}}
+
+  export-mac:
+    # Yes, macOS has the most stable support... Contrary to linux, the caching works, we can do adhoc-notarisation, and it's faster
+    name: Mac and Windows Exports
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Load Import Folder
+        uses: actions/cache/restore@v3
+        with:
+          path: src/.import
+          enableCrossOsArchive: true
+          key: Import-Mac-${{hashFiles('src/.import')}}
           restore-keys: |
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}
-            ${{github.job}}-${{env.BASE_BRANCH}}
-        continue-on-error: true
-      - name: Setup
+            Import-Mac-${{hashFiles('src/.import')}}
+            Import-Mac-
+            Import-
+      
+      - name: Download Godot
+        run: curl -L -o ../Godot_v${{env.GODOT_VERSION}}-stable_osx.universal.zip https://github.com/godotengine/godot/releases/download/${{env.GODOT_VERSION}}-stable/Godot_v${{env.GODOT_VERSION}}-stable_osx.universal.zip
+      
+      - name: Extract Godot
+        run: unzip -d .. ../Godot_v${{env.GODOT_VERSION}}-stable_osx.universal.zip
+      
+      - name: Create Export Template Directory
+        run: mkdir -v -p "${HOME}/Library/Application Support/Godot/templates/${{env.GODOT_VERSION}}.stable"
+      
+      - name: Get Export Templates from Cache
+        id: export-templates-cache
+        uses: actions/cache@v3
+        with:
+          path: ../Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz
+          key: Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz
+
+      - name: Download Godot Release Templates
+        if: steps.export-templates-cache.outputs.cache-hit != 'true'
+        run: curl -L -o ../Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz https://github.com/godotengine/godot/releases/download/${{env.GODOT_VERSION}}-stable/Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz
+
+      - name: Extract and Install Templates
         run: |
-          mkdir -v -p ~/.local/share/godot/templates
-          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
-      - name: Mac Build
+
+          unzip -j -d "${HOME}/Library/Application Support/Godot/templates/${{env.GODOT_VERSION}}.stable" ../Godot_v${{env.GODOT_VERSION}}-stable_export_templates.tpz
+          ls -la "${HOME}/Library/Application Support/Godot/templates/${{env.GODOT_VERSION}}.stable"
+      
+      - name: Create Build Folders
         run: |
           mkdir -v -p build/mac
-          cd src
-          godot -v --export "Mac OSX" ../build/mac/$EXPORT_NAME.zip
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+          mkdir -v -p build/mac-debug
+          mkdir -v -p build/windows
+          mkdir -v -p build/windows-debug
+
+      - name: Export MacOS Release
+        run: ../Godot.app/Contents/MacOS/Godot src/project.godot -v --export "Mac OSX" ../build/mac/$EXPORT_NAME.zip
+      
+      - name: Upload MacOS Release
+        uses: actions/upload-artifact@v3
         with:
           name: mac
           path: build/mac
   
-  export-mac-debug:
-    name: Mac Export (Debug)
-    runs-on: ubuntu-latest
-    container:
-      image: barichello/godot-ci:3.5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Load Cache
-        uses: actions/cache@v2
-        with:
-          path: src/.import
-          key: ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-          restore-keys: |
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-            ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}
-            ${{github.job}}-${{env.BASE_BRANCH}}
-        continue-on-error: true
-      - name: Setup
-        run: |
-          mkdir -v -p ~/.local/share/godot/templates
-          mv /root/.local/share/godot/templates/${GODOT_VERSION}.stable ~/.local/share/godot/templates/${GODOT_VERSION}.stable
-      - name: Mac Build
-        run: |
-          mkdir -v -p build/mac-debug
-          cd src
-          godot -v --export-debug "Mac OSX" ../build/mac-debug/${EXPORT_NAME}_debug.zip
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+      - name: Export MacOS Debug
+        run: ../Godot.app/Contents/MacOS/Godot src/project.godot -v --export-debug "Mac OSX" ../build/mac-debug/${EXPORT_NAME}_debug.zip
+      
+      - name: Upload MacOS Debug
+        uses: actions/upload-artifact@v3
         with:
           name: mac-debug
           path: build/mac-debug
+      
+      - name: Export Windows Release
+        run: ../Godot.app/Contents/MacOS/Godot src/project.godot -v --export "Windows Desktop" ../build/windows/$EXPORT_NAME.exe
+      
+      - name: Upload Windows Release
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows
+          path: build/windows
+  
+      - name: Export Windows Debug
+        run: ../Godot.app/Contents/MacOS/Godot src/project.godot -v --export-debug "Windows Desktop" ../build/windows-debug/${EXPORT_NAME}_debug.exe
+      
+      - name: Upload Windows Debug
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-debug
+          path: build/windows-debug
+
+      - name: Store Import Folder
+        uses: actions/cache/save@v3
+        with:
+          path: src/.import
+          enableCrossOsArchive: true
+          key: Import-Mac-${{hashFiles('src/.import')}}
 
 # Add Android (https://github.com/abarichello/godot-ci/blob/master/.gitlab-ci.yml#L63-L99)
-# Add automatic versioning

--- a/src/Data/UI/main_menu.gd
+++ b/src/Data/UI/main_menu.gd
@@ -1,7 +1,6 @@
 extends Control
 
 var save_path := "user://config.cfg"
-export var version = ""
 
 
 func _ready():
@@ -10,7 +9,11 @@ func _ready():
 
 	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
 
-	$Version.text = "Version: %s" % version
+	$Version.text = "Version: %s" % ProjectSettings["application/version/label"]
+	if ProjectSettings["application/version/broken"]:
+		$Version.add_color_override("font_color", Color.webmaroon)
+	elif ProjectSettings["application/version/dirty"]:
+		$Version.add_color_override("font_color", Color.yellow)
 	var openTimes = jSaveManager.get_value("open_times", 0)
 	openTimes += 1
 	jSaveManager.save_value("open_times", openTimes)
@@ -25,7 +28,7 @@ func _ready():
 		_on_PlayFront_pressed()
 
 	updateBottmLabels()
-	Logger.log("Using version: %s" % version)
+	Logger.log("Using version: %s" % ProjectSettings["application/version/label"])
 	Logger.vlog("Main menu loaded")
 
 

--- a/src/Data/UI/main_menu.tscn
+++ b/src/Data/UI/main_menu.tscn
@@ -22,10 +22,6 @@
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-version = "0.9.beta1"
 
 [node name="Background" type="TextureRect" parent="."]
 anchor_right = 1.0
@@ -52,21 +48,22 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = -76.0
 margin_top = -26.0
+margin_right = -8.0
+margin_bottom = -8.0
 grow_horizontal = 0
 grow_vertical = 0
 custom_fonts/font = ExtResource( 10 )
 text = "Version: 0.0"
 align = 2
 valign = 2
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="LabelMusic" type="Label" parent="."]
 anchor_top = 1.0
 anchor_bottom = 1.0
+margin_left = 8.0
 margin_top = -26.0
 margin_right = 86.0
+margin_bottom = -8.0
 grow_vertical = 0
 custom_fonts/font = ExtResource( 10 )
 text = "MENU_MUSIC:"
@@ -83,9 +80,6 @@ margin_right = 323.0
 margin_bottom = -1.05945
 theme = ExtResource( 5 )
 alignment = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="TextureRect" type="TextureRect" parent="Buttons"]
 margin_top = 34.0

--- a/src/addons/hasa1002.buildversion/LICENSE
+++ b/src/addons/hasa1002.buildversion/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/src/addons/hasa1002.buildversion/plugin.cfg
+++ b/src/addons/hasa1002.buildversion/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Build Version"
+description="Determines the current version based on the git state without causing SCM noise."
+author="Johannes Witt"
+version="1.0"
+script="plugin.gd"

--- a/src/addons/hasa1002.buildversion/plugin.gd
+++ b/src/addons/hasa1002.buildversion/plugin.gd
@@ -1,0 +1,37 @@
+tool
+extends EditorPlugin
+
+
+var running := true
+var version_exporter := preload("res://addons/hasa1002.buildversion/version_exporter.gd").new()
+
+
+func _enter_tree() -> void:
+	enable_plugin()
+	var interface := get_editor_interface()
+	var was_playing := false
+	while running:
+		yield(interface.get_tree(), "idle_frame")
+		if was_playing and !interface.is_playing_scene():
+			version_exporter.reset()
+		was_playing = interface.is_playing_scene()
+
+
+func _exit_tree() -> void:
+	disable_plugin()
+
+
+func enable_plugin() -> void:
+	running = true
+	add_export_plugin(version_exporter)
+
+
+func disable_plugin() -> void:
+	running = false
+	version_exporter.reset()
+	remove_export_plugin(version_exporter)
+
+
+func build() -> bool:
+	version_exporter.build()
+	return true

--- a/src/addons/hasa1002.buildversion/version_exporter.gd
+++ b/src/addons/hasa1002.buildversion/version_exporter.gd
@@ -1,0 +1,95 @@
+tool
+extends EditorExportPlugin
+
+
+var version_label := ""
+var last_generated_label := ""
+
+
+func _export_begin(_features: PoolStringArray, _is_debug: bool, _path: String, _flags: int) -> void:
+	build()
+
+
+func _export_end() -> void:
+	reset()
+
+
+func reset() -> void:
+	ProjectSettings["application/version/dirty"] = false
+	ProjectSettings["application/version/broken"] = false
+	ProjectSettings["application/version/custom"] = false
+	ProjectSettings["application/version/commit"] = ""
+	ProjectSettings["application/version/label"] = version_label
+	ProjectSettings.save()
+
+
+func build() -> void:
+	ProjectSettings["application/version/dirty"] = true
+	ProjectSettings["application/version/broken"] = true
+	ProjectSettings["application/version/custom"] = true
+	ProjectSettings["application/version/commit"] = ""
+	if ProjectSettings.has_setting("application/version/label") and last_generated_label != ProjectSettings["application/version/label"]:
+		version_label = ProjectSettings["application/version/label"]
+	var output := []
+	var exit := OS.execute("git", ["describe", "--all"], true, output, true)
+	if exit != 0:
+		printt(exit, output)
+		push_warning("Project used without SCM. No version info available.")
+		ProjectSettings["application/version/label"] = "%s CUSTOM BUILD" % version_label
+		last_generated_label = ProjectSettings["application/version/label"]
+		ProjectSettings.save()
+		return
+
+	var custom_build := "" if ("master" in output[0] or "main" in output[0] or "release" in output[0]) else ".custom.%s"
+	
+	exit = OS.execute("git", ["status", "-s"], true, output, true)
+	if exit != 0:
+		printt(exit, output)
+		push_warning("Failed to determine state.")
+		ProjectSettings["application/version/label"] = "%s CUSTOM BUILD" % version_label
+		last_generated_label = ProjectSettings["application/version/label"]
+		ProjectSettings.save()
+		return
+
+	var dirty := " DIRTY BRANCH" if !output[0].empty() else ""
+
+	exit = OS.execute("git", ["describe", "--tags", "--long" ,"--always", "--dirty=", "--broken=?"], true, output, true)
+	if exit != 0:
+		printt(exit, output)
+		push_warning("Failed to determine version.")
+		ProjectSettings["application/version/label"] = "% CUSTOM BUILD" % version_label
+		last_generated_label = ProjectSettings["application/version/label"]
+		ProjectSettings.save()
+		return
+
+	var parts: PoolStringArray = output[0].split("-", false)
+	var broken := " BROKEN" if "?" in parts[-1] else ""
+	var commit: String = parts[-1].left(len(parts[-1]) - (2 if broken else 1))
+
+	ProjectSettings["application/version/dirty"] = !dirty.empty()
+	ProjectSettings["application/version/broken"] = !broken.empty()
+	ProjectSettings["application/version/custom"] = !custom_build.empty()
+	ProjectSettings["application/version/commit"] = commit
+
+	if len(parts) < 3:
+		if !custom_build.empty():
+			custom_build = custom_build % commit
+		ProjectSettings["application/version/label"] = "v %s%s%s%s" % [commit, custom_build, broken, dirty]
+		last_generated_label = ProjectSettings["application/version/label"]
+		ProjectSettings.save()
+		return
+
+	commit = commit.right(1)
+	ProjectSettings["application/version/commit"] = commit
+	if !custom_build.empty():
+		custom_build = custom_build % commit
+
+	if (parts[1] == "0"):
+		ProjectSettings["application/version/label"] = "%s%s%s%s" % [parts[0], custom_build, broken, dirty]
+		last_generated_label = ProjectSettings["application/version/label"]
+		ProjectSettings.save()
+		return
+	ProjectSettings.set_setting("application/version/label", "%s.%s%s%s%s" % [parts[0], parts[1], custom_build, broken, dirty])
+	last_generated_label = ProjectSettings["application/version/label"]
+	ProjectSettings.save()
+

--- a/src/addons/jean28518.jTools/jSettings/JSettings.gd
+++ b/src/addons/jean28518.jTools/jSettings/JSettings.gd
@@ -79,6 +79,15 @@ func save_settings():
 		return
 	file.erase_section_key("", "_global_script_classes")
 	file.erase_section_key("", "_global_script_class_icons")
+
+	# We forcefully delete a good chunk of things that may get into our way
+	file.erase_section("network")
+	file.erase_section("editor_plugins")
+	file.erase_section("editor")
+	file.erase_section("autoload")
+	file.erase_section("audio")
+	file.erase_section("application")
+
 	err = file.save("user://override.cfg")
 	if err != OK:
 		Logger.err("Couldn't load user://override.cfg for _global_script_classes" + \

--- a/src/project.godot
+++ b/src/project.godot
@@ -410,6 +410,11 @@ boot_splash/bg_color=Color( 0.65098, 0.65098, 0.65098, 1 )
 config/icon="res://Data/Misc/logos/lts_logo_16.png"
 config/quit_on_go_back=false
 config/project_settings_override.editor="user://override_hack.cfg"
+version/dirty=false
+version/broken=false
+version/custom=false
+version/commit=""
+version/label="v0.9.beta1"
 
 [audio]
 
@@ -446,7 +451,7 @@ scene_naming=2
 
 [editor_plugins]
 
-enabled=PoolStringArray( "res://addons/HaSa1002.light-tools/plugin.cfg", "res://addons/libre_trainsim_modding_tools/plugin.cfg" )
+enabled=PoolStringArray( "res://addons/HaSa1002.light-tools/plugin.cfg", "res://addons/hasa1002.buildversion/plugin.cfg", "res://addons/libre_trainsim_modding_tools/plugin.cfg" )
 
 [game]
 


### PR DESCRIPTION
# Autoversion 
Basically, it asks git for the current ref and tag and calculates a version string as well as some convenience stats like branch being dirty or broken.
It falls back to the version set in the project settings if there's no git.
It also ensures that the project setting changes are as invisible to git as possible by calculating them only when the project is played or exported and resetting them immediatly once it was closed. I hope to prevent `project.godot` change spam...


Fixes #371 

*Edit: Made it an addon now https://github.com/HaSa1002/godot-build-version. I still need to make a logo and upload it to the asset library.*

# CI Updates

As mentioned down below, we have to update our CI pipeline anyway so I took a shot and got rid of the container action. We finally have ad hoc signed Mac builds that people should be able to open with good will. Using native mac builds actually sped up our pipeline considerably because the headless linux builds seem to fail to properly cache *all* imports. Sadly, we can't use the normal editor build, because Godot fails to acquire a non existent X11 interface hence the reason the headless builds exist. So I'd consider this a Godot bug until further notice but I am not patient enough to dig into the issue and file a bug report and fix.

The situation on Windows isn't that much better. I have no idea how to get that natively working. You get like the first line of output and then it hangs or it outputs stuff and Godot returns while still executing and thus the job finished before the export is done. I decided to drop the ball for now (which means no rcedited binaries but that's fine IMHO) and let the MacOS builder export for windows, too. The two builders should be about the same speed, even though the latter one has to export two more builds. 

It's not really and issue and I basically moved the Windows builds to be generated on a Mac from being generated on a dockerised ubuntu ¯\\_(ツ)_/¯


Fixes #209

# CI Future

I left the Windows builds as disabled job for now. I feel like that's fixable but not a top priority right now. I'd like to add automatic uploads to itch.io but we have to decide if we use another itch.io page and in which frequency we gonna update it. I have a copyable action snippet ready. I'd favour updates as they come without scheduling. On the topic of using a new page or the old, however, I've no idea. Both have their benefits and drawbags. If fail to decide, I am gonna toss a coin to your witcher and that's gonna be the decision we gonna stick to.

On this very topic is also release distribution. I feel like we are this close and we should start considering our infrastructure to ease that process. I think about adding a dedicated workflow run on tag or release that gets the latest release of our maps and adds them to the archives. Maybe adding a system that checks commits for keywords and creates a changelog accordingly. Idk that's dreaming, really.

Lastly I'd like to run the potential unit tests on CI, too.