### PR TITLE
Prioritize emergency braking over restrictive mode

### DIFF
--- a/src/Data/Scripts/PZBModule.gd
+++ b/src/Data/Scripts/PZBModule.gd
@@ -234,6 +234,9 @@ func _on_reverser_changed(state: int) -> void:
 
 
 func restrictive_mode() -> void:
+	if pzb_mode & PZBMode.EMERGENCY:
+		return
+
 	pzb_mode &= ~PZBMode.MASK_MODE   # disable current mode
 	pzb_mode |= PZBMode.RESTRICTIVE  # enable restrictive
 


### PR DESCRIPTION
Closes #461

In the `_process` method of the PZB module, the check for restrictive mode runs periodically. This would override the emergency state that was triggered by the PZB leading to the game not realizing that the emergency brake occurred due to PZB.

Short clip showing that the problem in the tutorial was fixed:

[Peek 2023-02-05 01-46.webm](https://user-images.githubusercontent.com/32276754/216795745-c944ff2d-49a7-4d67-93ca-2a7e2c0c0130.webm)
