### PR TITLE
Fix pressing escape in tutorial message leading to unexpected behavior

### DIFF
--- a/src/Data/UI/pause.gd
+++ b/src/Data/UI/pause.gd
@@ -11,9 +11,9 @@ var player: LTSPlayer
 
 
 func _unhandled_input(_event) -> void:
-	if Input.is_action_just_pressed("Escape"):
+	if Input.is_action_just_pressed("Escape") and !get_parent().get_node("TextBox").opened:
 		get_tree().paused = !get_tree().paused
-		visible = !visible
+		visible = get_tree().paused
 		if visible:
 			_saved_ingame_pause = Root.ingame_pause
 			Root.ingame_pause = false

--- a/src/Data/UI/text_box.gd
+++ b/src/Data/UI/text_box.gd
@@ -5,6 +5,7 @@ signal closed
 
 
 var _previous_mouse_mode: int
+var opened := false
 
 func _unhandled_key_input(_event) -> void:
 	if Input.is_action_just_released("ui_accept"):
@@ -18,11 +19,13 @@ func message(text: String) -> void:
 	$MarginContainer/VBoxContainer/Message.text = text
 	visible = true
 	get_tree().paused = true
+	opened = true
 	$MarginContainer/VBoxContainer/Ok.grab_click_focus()
 
 
 func _on_Ok_pressed():
 	visible = false
 	get_tree().paused = false
+	opened = false
 	Input.set_mouse_mode(_previous_mouse_mode)
 	emit_signal("closed")


### PR DESCRIPTION
Fixed problem where pressing Esc while a message box is shown would lead to the game opening the pause menu but continuing the game, leading to a reversed state where the game continues in the pause screen and pauses when closing the pause screen.

Clip showing the state before this change:

[Peek 2023-02-05 01-53.webm](https://user-images.githubusercontent.com/32276754/216795998-b0314b4e-3885-47b7-94ae-908ce8339fdc.webm)

Clip showing that the problem has been fixed:

[Peek 2023-02-05 02-01.webm](https://user-images.githubusercontent.com/32276754/216796228-f53ec0ad-dcb2-42c0-9d17-56b4e857e899.webm)
