### PR TITLE
Fix: Restart scenario while message open

### DIFF
--- a/src/Data/UI/pause.gd
+++ b/src/Data/UI/pause.gd
@@ -63,7 +63,7 @@ func _on_StationJumper_station_index_selected(station_index: int) -> void:
 
 
 func _on_RestartScenario_pressed() -> void:
-	_on_Back_pressed()
+	Root.reset_game_pause()
 	jEssentials.remove_all_pending_delayed_calls()
 	jAudioManager.clear_all_sounds()
 	var _unused = get_tree().reload_current_scene()


### PR DESCRIPTION
This fixes a bug where you get stuck on the loading screen when you hit "Restart scenario" while a message is open.

This happens, because only the "pause_menu" pause factor is set to false when restarting and the "message" factor is left true.