### PR TITLE
Add PassengerCameras to JFR1_Grey

### DIFF
--- a/src/Data/Modules/FreeCamera.tscn
+++ b/src/Data/Modules/FreeCamera.tscn
@@ -7,3 +7,4 @@ pause_mode = 2
 far = 1000.0
 script = ExtResource( 1 )
 fixed = false
+handleWorldOriginShifts = true

--- a/src/Data/Scripts/Camera.gd
+++ b/src/Data/Scripts/Camera.gd
@@ -21,6 +21,9 @@ export var fixed: bool = true
 # whether to apply or not acceleration effect on camera
 export var accel: bool = false
 
+# whether to handle world origin shifts - enable if camera has no parent that handles this!
+export var handleWorldOriginShifts: bool = false
+
 # Saves the camera position at the beginning. The Camera Position will be changed, when the train is accelerating, or braking
 onready var cameraZeroTransform: Transform = transform
 
@@ -42,7 +45,8 @@ func _ready() -> void:
 
 
 func _on_world_origin_shifted(delta: Vector3):
-	translation += delta
+	if handleWorldOriginShifts:
+		translation += delta
 
 
 func _input(event) -> void:

--- a/src/Data/Scripts/Player.gd
+++ b/src/Data/Scripts/Player.gd
@@ -76,6 +76,7 @@ var camera_state: int = CameraState.CABIN_VIEW
 var camera_mid_point: Vector3 = Vector3(0,2,0)
 var cameraY: float = 90
 var cameraX: float = 0
+var passengerCameras := []
 
 var mouseSensitivity: float = 10
 
@@ -252,6 +253,14 @@ func ready() -> void:
 		soll_command = 0
 
 	spawnWagons()
+
+	# HACK: Register player passenger cameras. Refactor in future train refactor!
+	passengerCameras.clear()
+	if name == "Player":
+		for wagon in wagonsI:
+			for node in wagon.get_children():
+				if node.is_in_group("PlayerCameras"):
+					passengerCameras.append(node)
 
 	## Prepare Signals:
 	if not ai:
@@ -677,12 +686,11 @@ func handleCamera(delta: float) -> void:
 		cam.owner = world
 		cam.transform = transform.translated(camera_mid_point)
 
-	var playerCameras: Array = get_tree().get_nodes_in_group("PlayerCameras")
 	for i in range(3, 9):
-		if Input.is_action_just_pressed("player_camera_" + str(i)) and playerCameras.size() >= i - 2:
+		if Input.is_action_just_pressed("player_camera_" + str(i)) and passengerCameras.size() >= i - 2:
 			wagonsVisible = true
 			camera_state = i
-			playerCameras[i -3].current = true
+			passengerCameras[i-3].current = true
 			$Cabin.hide()
 			remove_free_camera()
 

--- a/src/Trains/JFR1/JFR1_Grey.tscn
+++ b/src/Trains/JFR1/JFR1_Grey.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=68 format=2]
+[gd_scene load_steps=69 format=2]
 
 [ext_resource path="res://Trains/JFR1/Door.obj" type="ArrayMesh" id=1]
+[ext_resource path="res://Data/Scripts/Camera.gd" type="Script" id=2]
 [ext_resource path="res://Resources/Materials/Black_Plastic.tres" type="Material" id=3]
 [ext_resource path="res://Trains/JFR1/Wagon_Grey.tres" type="Material" id=4]
 [ext_resource path="res://Resources/Materials/LEDLamp_Bright.tres" type="Material" id=5]
@@ -851,6 +852,11 @@ visible = false
 script = ExtResource( 33 )
 length = 14.0
 
+[node name="PassengerCamera1" type="Camera" parent="Wagon1" groups=["PlayerCameras"]]
+transform = Transform( -0.790797, 0, -0.612079, 0, 1, 0, 0.612079, 0, -0.790797, 1.09673, 2.40611, 1.18214 )
+script = ExtResource( 2 )
+accel = true
+
 [node name="MeshInstance" type="MeshInstance" parent="Wagon1"]
 cast_shadow = 2
 mesh = ExtResource( 27 )
@@ -1172,6 +1178,11 @@ spot_angle = 77.4
 visible = false
 script = ExtResource( 33 )
 length = 14.0
+
+[node name="PassengerCamera2" type="Camera" parent="DriverCabinF" groups=["PlayerCameras"]]
+transform = Transform( -0.790797, 0, -0.612079, 0, 1, 0, 0.612079, 0, -0.790797, 1.097, 2.406, -1.182 )
+script = ExtResource( 2 )
+accel = true
 
 [node name="MeshInstance" type="MeshInstance" parent="DriverCabinF"]
 transform = Transform( -1, 0, -3.25841e-07, 0, 1, 0, 3.25841e-07, 0, -1, 0, 0, 0 )
@@ -1567,6 +1578,11 @@ visible = false
 script = ExtResource( 33 )
 length = 15.0
 pantographEnabled = true
+
+[node name="PassengerCamera3" type="Camera" parent="DriverCabinB" groups=["PlayerCameras"]]
+transform = Transform( -0.790797, 0, -0.612079, 0, 1, 0, 0.612079, 0, -0.790797, 1.097, 2.406, -1.182 )
+script = ExtResource( 2 )
+accel = true
 
 [node name="MeshInstance" type="MeshInstance" parent="DriverCabinB"]
 cast_shadow = 2


### PR DESCRIPTION
Fixes #465. The issue was that the passenger cameras were never added to JFR1_Grey. The solution seems to be to just copy the cameras from JFR1_Red into JFR1_Grey.

The above *should* work, however in testing the camera switching seemed to be unreliable, working in one direction of U2_Nuremberg but not the other (Hauptbahnhof-Röthenbach is problematic). When it didn't work, I ended up in a black screen (GUI still showing though) without audio somewhere across the map. However, this could be due to the game maxing out my GPU's 6GBs of VRAM on that map, making testing very difficult. ~~I also can't select JFR1_Grey on the testing track due to #484.~~

I would appreciate if someone could test it on their machine, or comment if there's an obvious issue with my solution. It could be that I missed some custom script file for one of the train types 🤷‍♂️