### PR TITLE
Add generic pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/generic_pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/generic_pull_request.md
@@ -1,0 +1,36 @@
+---
+name: Generic Pull Request
+about: Submit a generic pull request
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Summary
+
+A clear and concise description of what this PR does.
+
+### Goals
+
+This PR has the following goals:
+
+- Fix that thing ...
+- Add something ...
+- Refactor another thing ...
+
+### Details
+
+A clear and more detailed description of your changes and (ideally) your reasoning behind them. Go into as much or as little detail as you want, but remember that whoever reads it should be able to understand it.
+
+### Notes for reviewers
+
+Any feedback is appreciated. In particular, I would like your comments on:
+
+- This change
+- That change
+- Another change
+
+### Additional information
+
+Add any other context about your PR such as screenshots or video documentation here.


### PR DESCRIPTION
### Summary

This PR adds a generic issue template.

### Goals

This PR has the following goals:

- Add a generic pull request template usable in GitHub

### Details

I have added a pull request template at `.github/PULL_REQUEST_TEMPLATE/generic_pull_request.md`. The sections and formatting are identical to what this PR uses, so you can see how it looks in practice.

As always, this template has some redundancy (for example, a good summary typically already covers the PR's goals), but I think this is acceptable considering the improved ease of quickly grasping what a PR is about.

### Notes for reviewers

Any feedback is appreciated. In particular, I would like your comments on:

- Labels. I haven't set any default labels for the template. I think this is fine as this is a generic template, but feel free to comment.

### Additional information

None
