### PR TITLE
Fix 'ERROR: Resource file not found: res://.'

### DIFF
--- a/src/addons/jean28518.jTools/jAudioManager/JAudioManager.gd
+++ b/src/addons/jean28518.jTools/jAudioManager/JAudioManager.gd
@@ -13,6 +13,11 @@ enum AudioBus {
 func play(soundPath: String, loop: bool = false, pausable: bool = true, volume_db: float = 0.0 , bus: int = AudioBus.GAME):
 	var audioStreamPlayer = AudioStreamPlayer.new()
 
+	# Return early if soundPath is empty
+	if soundPath.empty() or soundPath in ["res://", "user://"]:
+		Logger.vlog("jAudioManager: soundPath is '" + soundPath + "', returning early")
+		return
+
 	if not resourceTable.has(soundPath) or resourceTable[soundPath] == null:
 		resourceTable[soundPath] = load(soundPath)
 		if resourceTable[soundPath] == null:


### PR DESCRIPTION
In Hainfurt and U2-Nuremberg, for any station that has no announcement sound set, the set soundPath appears to be 'res://'. This resulted in JAudioManager throwing the `ERROR: Resource file not found: res://.` error at each of these stations.

The simple fix is to return early if the sound path is (obviously) empty, e.g. `""` or `"res://"` or `"user://"` (although `"user://"` shouldn't be used anyway...).

Example from one of my logs:

```
[2023-02-27 15:54:05][INFO](Null) Sending Message: The next station is Marchern. It is 1km away.
Loading resource: res://
ERROR: Resource file not found: res://.
   at: _load (core/io/resource_loader.cpp:275) - Condition "!file_check->file_exists(p_path)" is true. Returned: RES()
jAudioManager:  not found. Please give in a appropriate path beginning with res://
   At: res://addons/jean28518.jTools/jAudioManager/JAudioManager.gd:19:play()
```