### PR TITLE
Fix build version not having enough data to create version

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Load Import Folder
         uses: actions/cache/restore@v3
@@ -100,6 +102,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Load Import Folder
         uses: actions/cache/restore@v3
@@ -169,6 +173,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Load Import Folder
         uses: actions/cache/restore@v3


### PR DESCRIPTION
By default most of the git data is ommitted. Fetching the whole history should fix that.