### PR TITLE
Fix message text changed when opening settings

### DIFF
--- a/src/Data/UI/text_box.gd
+++ b/src/Data/UI/text_box.gd
@@ -11,7 +11,7 @@ func message(text: String) -> void:
 	_previous_mouse_mode = Input.get_mouse_mode()
 	assert(_previous_mouse_mode != null)
 	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-	$MarginContainer/VBoxContainer/Message.text = text
+	$MarginContainer/VBoxContainer/Message.set_text(text)
 	visible = true
 	Root.set_game_pause("message", true)
 	$MarginContainer/VBoxContainer/Ok.grab_focus()

--- a/src/Data/UI/translated_rich_rext_label.gd
+++ b/src/Data/UI/translated_rich_rext_label.gd
@@ -15,7 +15,8 @@ func _notification(what: int) -> void:
 
 
 func set_text(text: String) -> void:
-	.set_text(tr(text))
+	translation_id = text
+	update_text()
 
 
 func update_text() -> void:


### PR DESCRIPTION
Fixes #482

When opening a message, only the text was set and not the translation_id. When opening the settings, the language is updated and then the message is updated using the translation_id, which still was the default text