### PR TITLE
Fix passengers walking through doors when the other side is open

### DIFF
--- a/src/Data/Scripts/Enums/door_side.gd
+++ b/src/Data/Scripts/Enums/door_side.gd
@@ -1,0 +1,13 @@
+class_name DoorSide
+
+enum {
+	UNASSIGNED = 0,
+	LEFT = 1,
+	RIGHT = 2
+}
+
+enum TypeHint {
+	UNASSIGNED = 0,
+	LEFT = 1,
+	RIGHT = 2
+}

--- a/src/Data/Scripts/PassengerDoor.gd
+++ b/src/Data/Scripts/PassengerDoor.gd
@@ -1,4 +1,6 @@
 extends PassengerPathNode
 
+var side := DoorSide.UNASSIGNED
+
 func _init():
 	type = Type.DOOR

--- a/src/Data/Scripts/Person.gd
+++ b/src/Data/Scripts/Person.gd
@@ -32,7 +32,7 @@ func _process(delta: float) -> void:
 var leave_wagon_timer: float = 0
 func handleWalk(delta: float) -> void:
 	# If Doors where closed to early, and the person is at the station..
-	if transitionToWagon == true and not (attachedWagon.lastDoorRight or attachedWagon.lastDoorLeft):
+	if transitionToWagon and not is_assigned_door_open():
 		if attachedWagon.player.current_station_node != attachedStation:
 			transitionToWagon = false
 			destinationPos.clear()
@@ -100,6 +100,11 @@ func handleWalk(delta: float) -> void:
 			rotation.y = atan(vector_delta.x/vector_delta.z)
 		else:
 			rotation.y = atan(vector_delta.x / vector_delta.z) + PI
+
+
+func is_assigned_door_open() -> bool:
+	assert(transitionToWagon)
+	return (attachedWagon.lastDoorRight and assignedDoor.side == DoorSide.RIGHT) or (attachedWagon.lastDoorLeft and assignedDoor.side == DoorSide.LEFT)
 
 
 func leave_current_wagon()-> void:

--- a/src/Data/Scripts/Wagon.gd
+++ b/src/Data/Scripts/Wagon.gd
@@ -216,9 +216,11 @@ func registerDoors() -> void:
 		if child.is_in_group("PassengerDoor"):
 			if child.translation[2] > 0:
 				child.translation += Vector3(0,0,0.5)
+				child.side = DoorSide.RIGHT
 				rightDoors.append(child)
 			else:
 				child.translation -= Vector3(0,0,0.5)
+				child.side = DoorSide.LEFT
 				leftDoors.append(child)
 
 

--- a/src/Data/Scripts/Wagon.gd
+++ b/src/Data/Scripts/Wagon.gd
@@ -300,11 +300,10 @@ var leavingPassengerNodes := []
 ## on the given side, sends the routeInformation for that to the persons.
 func sendPersonsToDoor(doorDirection: int, proportion: float = 0.5) -> void:
 	leavingPassengerNodes.clear()
-	 #0: No platform, 1: at left side, 2: at right side, 3: at both sides
 	var possibleDoors := []
-	if doorDirection == 1 or doorDirection == 3: # Left
+	if doorDirection == PlatformSide.LEFT or doorDirection == PlatformSide.BOTH:
 		possibleDoors.append_array(leftDoors)
-	if doorDirection == 2 or doorDirection == 3: # Right
+	if doorDirection == PlatformSide.RIGHT or doorDirection == PlatformSide.BOTH:
 		possibleDoors.append_array(rightDoors)
 
 	if possibleDoors.empty():

--- a/src/project.godot
+++ b/src/project.godot
@@ -109,6 +109,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://Data/Scripts/DistanceMonitor.gd"
 }, {
+"base": "Reference",
+"class": "DoorSide",
+"language": "GDScript",
+"path": "res://Data/Scripts/Enums/door_side.gd"
+}, {
 "base": "CameraBase",
 "class": "EditorCamera",
 "language": "GDScript",
@@ -390,6 +395,7 @@ _global_script_class_icons={
 "CustomItemList": "",
 "DebugCamera": "",
 "DistanceMonitor": "",
+"DoorSide": "",
 "EditorCamera": "",
 "EditorInfo": "",
 "ExportTrack": "",


### PR DESCRIPTION
Fixes #500.

Previously, passengers only checked whether any doors (whether left or right) are open to decide whether to walk or not.

This PR adds a `side` variable to `PassengerDoor`. It is assigned in `Wagon.gd`, which already sorted doors into left and right internally anyway. Now, the passengers simply have to check what side their door is on and whether that side of doors is currently open.

Additionally, `Wagon.gd` now uses the `PlatformSide` enum instead of hardcoding these values.