### PR TITLE
Update CI to use Godot 3.5.2

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GODOT_VERSION: 3.5.1
+  GODOT_VERSION: 3.5.2
   EXPORT_NAME: Libre_TrainSim
 
 jobs:


### PR DESCRIPTION
This updates the workflow to test exports using Godot 3.5.2 instead of 3.5.1