### PR TITLE
Fix get_chunks to properly return surrounding chunks

### DIFF
--- a/src/Data/Scripts/chunk_manager.gd
+++ b/src/Data/Scripts/chunk_manager.gd
@@ -41,20 +41,12 @@ static func string_to_chunk(chunk: String) -> Vector3:
 
 
 func get_chunks(around: Vector3, distance: int):
-	var chunks := [
-		chunk_to_string(Vector3(around.x, 0, around.z)),
-	]
-	for i in range(1, distance + 1):
-		chunks.append_array([
-			chunk_to_string(Vector3(around.x - i, 0, around.z)),
-			chunk_to_string(Vector3(around.x - i, 0, around.z - i)),
-			chunk_to_string(Vector3(around.x - i, 0, around.z + i)),
-			chunk_to_string(Vector3(around.x + i, 0, around.z)),
-			chunk_to_string(Vector3(around.x + i, 0, around.z - i)),
-			chunk_to_string(Vector3(around.x + i, 0, around.z + i)),
-			chunk_to_string(Vector3(around.x, 0, around.z - i)),
-			chunk_to_string(Vector3(around.x, 0, around.z + i)),
-		])
+	var chunks := []
+	for i in range(-distance, distance + 1):
+		for j in range(-distance, distance + 1):
+			var offset := Vector3(i, 0, j)
+			if ceil(offset.length()) <= distance:
+				chunks.append(chunk_to_string(around + offset))
 	return chunks
 
 
@@ -150,10 +142,11 @@ func _unload_old_chunks(saving: bool = false):
 	var chunks_to_unload = loader._loaded_chunks.duplicate()
 
 	# chunks_to_unload = all chunks further away than treshold
+	var unload_distance: float = ProjectSettings["game/gameplay/chunk_unload_distance"]
 	if not saving:
 		for chunk_name in loader._loaded_chunks:
 			var chunk_pos = string_to_chunk(chunk_name)
-			if active_chunk.distance_to(chunk_pos) <= ProjectSettings["game/gameplay/chunk_unload_distance"]:
+			if active_chunk.distance_to(chunk_pos) <= unload_distance:
 				chunks_to_unload.erase(chunk_name)
 
 	if Root.Editor:


### PR DESCRIPTION
Fixes #523

We can make code simple to understand with just iterating within `[-distance, distance+1]` as proposed within pr, as it is not necessary to optimize code right now.

or we can do only 1/4 or 1/8 semicircle rotations like
```
	var chunks := [
		chunk_to_string(Vector3(around.x, 0, around.z)),
	]
	for i in range(0, distance + 1):
		for j in range(0, distance + 1):
			if i + j == 0: continue
			var offset := Vector3(i, 0, j)
			if ceil(offset.length()) <= distance:
				var diagonal := Vector3(-i, 0, j)
				chunks.append_array([
					chunk_to_string(around + offset),
					chunk_to_string(around - offset),
					chunk_to_string(around + diagonal),
					chunk_to_string(around - diagonal),
					])
	return chunks
```

I vote for readability, so PR is plain and straight forward