### PR TITLE
Spawn first rail when chunk_0_0 unloaded

### DIFF
--- a/src/Editor/Scripts/Editor.gd
+++ b/src/Editor/Scripts/Editor.gd
@@ -1028,7 +1028,8 @@ func _spawn_poles_for_rail(rail: Node) -> void:
 
 	rail.track_objects.append(track_object)
 
-	var chunk_pos = $World.chunk_manager.position_to_chunk(rail.global_transform.origin)
+	var camera_position = $Camera.global_transform.origin
+	var chunk_pos = $World.chunk_manager.position_to_chunk(camera_position)
 	var chunk_name = $World.chunk_manager.chunk_to_string(chunk_pos)
 	var chunk = $World/Chunks.get_node(chunk_name)
 


### PR DESCRIPTION
Fixes #438 

Steps to reproduce:

1. Create new world
2. Move camera away from chunk_0_0 so it unloads (i.e. to 4 0 with visibility of 2 chunks)
3. Save world
4. Load world. Move further 1 chunk to trigger chunk_0_0 loaded by default to unload
5. Try to place first rail within the map

Core reason is that preloaded rail origin is used and it lead to chunk which is not available.

Proposal is to use current camera origin right away.