### PR TITLE
Door states and Person navigation improvements

### DIFF
--- a/src/Data/Screens/ScreenSpeedometer/screen_speedometer.gd
+++ b/src/Data/Screens/ScreenSpeedometer/screen_speedometer.gd
@@ -53,8 +53,8 @@ func _process(delta: float) -> void:
 
 
 var lastAutoPilot: bool = false
-func update_display(speed: float, command: float, doorLeft: bool, doorRight: bool,
-					doorsClosing: float, enforced_braking: bool, autopilot: bool,
+func update_display(speed: float, command: float, door_left: bool, door_right: bool,
+					doors_closing: bool, enforced_braking: bool, autopilot: bool,
 					speedLimit: float, engine: bool, reverser: int):
 	## Tachos:
 	$SpeedPointer.rotation = SpeedPointerZero + (SpeedPerKmH * speed)
@@ -74,13 +74,13 @@ func update_display(speed: float, command: float, doorLeft: bool, doorRight: boo
 		$Info/EnforcedBraking.visible = false
 
 	## Doors:
-	if doorsClosing:
+	if doors_closing:
 		$Doors.visible = blink_status
 	else:
 		$Doors.visible = true
-	$Doors/Right.visible = doorRight
-	$Doors/Left.visible = doorLeft
-	$Doors/Door.visible = doorLeft or doorRight
+	$Doors/Right.visible = door_right
+	$Doors/Left.visible = door_left
+	$Doors/Door.visible = door_left or door_right
 
 	$Reverser/Forward.visible = reverser == ReverserState.FORWARD
 	$Reverser/Backward.visible = reverser == ReverserState.REVERSE

--- a/src/Data/Scripts/CustomScenarioTemplate.gd
+++ b/src/Data/Scripts/CustomScenarioTemplate.gd
@@ -21,7 +21,7 @@ func scenario1():
 				next_step() # move on to next step
 		1:
 			message = "Great! To close the Doors, press 'o'.\n\nWhith 'i' you can open the left one,\nwith 'p' you open the right door."
-			if  not (player.doorRight or player.doorLeft):
+			if player.are_doors_closed():
 				next_step()
 		2:
 			message = "Last message of custom scenario. Thanks for playing!"

--- a/src/Data/Scripts/Enums/door_state.gd
+++ b/src/Data/Scripts/Enums/door_state.gd
@@ -1,0 +1,92 @@
+class_name DoorState
+
+# Description
+#
+# CLOSED: 
+#	Door is fully closed.
+#	New Person transition is forbidden.
+# OPENED: 
+#	Door is fully opened.
+#	New Person transition is allowed.
+# OPENING: 
+#	Door is trasiting to OPENED state.
+#	No pathfinding allowed.
+# CLOSING: 
+#	Door is trasiting to CLOSED state. 
+#	New Person transition is forbidden. 
+#	Person already is transition is allowed to continue.
+# HALTED: 
+#	Door is not transitining. 
+#	New Person transition is forbidden. 
+#	Animations/SFX should stop. 
+#	Special state for power cut-off (pantograf).
+
+# Door state transitions:
+#
+#	init 	-> CLOSED
+#	CLOSED  -> OPENING
+#	OPENING -> OPENED | HALTED | CLOSING
+#	CLOSING -> CLOSED | HALTED | OPENING
+#	OPENED  -> CLOSING
+#	HALTED  -> OPENING | CLOSING
+
+enum State {
+	HALTED,
+	CLOSED,
+	OPENED,
+	CLOSING,
+	OPENING
+}
+
+var state: int = State.CLOSED
+
+signal state_changed(state) # int, enum value
+
+func open() -> void:
+	if state == State.OPENED:
+		assert(false, "Doors are already in opened state.")
+		return
+	_set_state(State.OPENING)
+
+
+func is_opened() -> bool:
+	return state == State.OPENED
+
+
+func close() -> void:
+	if state == State.CLOSED:
+		assert(false, "Doors are already in closed state.")
+		return
+	_set_state(State.CLOSING)
+
+
+func is_closed() -> bool:
+	return state == State.CLOSED
+
+
+func is_halted() -> bool:
+	return state == State.HALTED
+
+
+func is_opening() -> bool:
+	return state == State.OPENING
+
+
+func is_closing() -> bool:
+	return state == State.CLOSING
+
+func _init() -> void:
+	state = State.CLOSED
+
+func _set_state(newState: int) -> void:
+	state = newState
+	emit_signal("state_changed", state)
+	
+
+func _on_animation_transition_finished(animation: String) -> void:
+	if animation == "open":
+		match(state):
+			State.CLOSING:
+				_set_state(State.CLOSED)
+			State.OPENING:
+				_set_state(State.OPENED)

--- a/src/Data/Scripts/HUD.gd
+++ b/src/Data/Scripts/HUD.gd
@@ -27,7 +27,7 @@ func _process(_delta: float) -> void:
 	$FPS.text = String(Engine.get_frames_per_second())
 	update_nextTable()
 	$IngameInformation/TrainInfo/Screen1.update_display(Math.speed_to_kmh(player.speed), \
-			player.technicalSoll, player.doorLeft, player.doorRight, player.doorsClosing,\
+			player.technicalSoll, player.door_left.is_opened(), player.door_right.is_opened(), player.are_doors_closing(),\
 			player.enforced_braking, player.automaticDriving,\
 			player.currentSpeedLimit, player.engine, player.reverser)
 

--- a/src/Data/Scripts/PassengerDoor.gd
+++ b/src/Data/Scripts/PassengerDoor.gd
@@ -1,6 +1,6 @@
 extends PassengerPathNode
 
-var side := DoorSide.UNASSIGNED
+export (DoorSide.TypeHint) var side := DoorSide.UNASSIGNED
 
-func _init():
+func _init() -> void:
 	type = Type.DOOR

--- a/src/Data/Scripts/Person.gd
+++ b/src/Data/Scripts/Person.gd
@@ -51,7 +51,7 @@ func handleWalk(delta: float) -> void:
 			attachedWagon.registerPerson(self, assignedDoor)
 			assignedDoor = null
 		if transitionToStation and attachedWagon.player.whole_train_in_station \
-				and (attachedWagon.lastDoorRight or attachedWagon.lastDoorLeft):
+				and attachedWagon.is_any_doors_opened():
 			leave_wagon_timer += delta
 			if leave_wagon_timer > 1.8:
 				leave_wagon_timer = 0
@@ -104,9 +104,12 @@ func handleWalk(delta: float) -> void:
 
 func is_assigned_door_open() -> bool:
 	assert(transitionToWagon)
-	return not attachedWagon.lastDoorsClosing and (
-				(attachedWagon.lastDoorRight and assignedDoor.side == DoorSide.RIGHT) or 
-				(attachedWagon.lastDoorLeft and assignedDoor.side == DoorSide.LEFT))
+	match assignedDoor.side:
+		DoorSide.RIGHT:
+			return attachedWagon.door_right.is_opened()
+		DoorSide.LEFT:
+			return attachedWagon.door_left.is_opened()		
+	return false
 
 
 func leave_current_wagon()-> void:

--- a/src/Data/Scripts/TrainInfo.gd
+++ b/src/Data/Scripts/TrainInfo.gd
@@ -22,10 +22,10 @@ func update_info(player: LTSPlayer) -> void:
 
 	## Doors:
 	$ScrollContainer/VBoxContainer/Doors.visible = player.doors
-	if not (player.doorLeft or player.doorRight):
+	if player.are_doors_closed():
 		$ScrollContainer/VBoxContainer/Doors/dot.texture = green
 	else:
-		if player.doorsClosing:
+		if player.are_doors_closing():
 			$ScrollContainer/VBoxContainer/Doors/dot.texture = orange
 		else:
 			$ScrollContainer/VBoxContainer/Doors/dot.texture = red

--- a/src/Trains/JFR1/JFR1_Grey.tscn
+++ b/src/Trains/JFR1/JFR1_Grey.tscn
@@ -1030,12 +1030,14 @@ transform = Transform( -1, 0, -3.25841e-07, 0, 1, 0, 3.25841e-07, 0, -1, -5.7627
 
 [node name="PassengerDoor" parent="Wagon1/Doors" instance=ExtResource( 43 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4.72651, 1.1985, 1.48181 )
+side = 2
 
 [node name="PassengerDoor3" parent="Wagon1/Doors" instance=ExtResource( 43 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0161424, 1.1985, 1.48181 )
 
 [node name="PassengerDoor2" parent="Wagon1/Doors" instance=ExtResource( 43 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4.64143, 1.1985, -1.46619 )
+side = 1
 
 [node name="PassengerDoor4" parent="Wagon1/Doors" instance=ExtResource( 43 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00276282, 1.1985, -1.4819 )

--- a/src/Trains/JFR1/JFR1_Red.tscn
+++ b/src/Trains/JFR1/JFR1_Red.tscn
@@ -1004,12 +1004,14 @@ material/1 = ExtResource( 31 )
 
 [node name="PassengerDoor" parent="Wagon1/Doors" instance=ExtResource( 10 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4.72651, 1.1985, 1.48181 )
+side = 2
 
 [node name="PassengerDoor3" parent="Wagon1/Doors" instance=ExtResource( 10 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0161424, 1.1985, 1.48181 )
 
 [node name="PassengerDoor2" parent="Wagon1/Doors" instance=ExtResource( 10 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4.64143, 1.1985, -1.46619 )
+side = 1
 
 [node name="PassengerDoor4" parent="Wagon1/Doors" instance=ExtResource( 10 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.00276282, 1.1985, -1.4819 )

--- a/src/Trains/JFR1/SpecificScripting.gd
+++ b/src/Trains/JFR1/SpecificScripting.gd
@@ -29,7 +29,7 @@ func _process(_delta: float) -> void:
 	if not is_ready:
 		is_ready = true
 		ready()
-	get_node("../Cabin/DisplayMiddle/Display").update_display(Math.speed_to_kmh(player.speed), player.technicalSoll, player.doorLeft, player.doorRight, player.doorsClosing, player.enforced_braking, player.automaticDriving, player.currentSpeedLimit, player.engine, player.reverser)
+	get_node("../Cabin/DisplayMiddle/Display").update_display(Math.speed_to_kmh(player.speed), player.technicalSoll, player.door_left.is_closing(), player.door_right.is_closing(), player.are_doors_closing(), player.enforced_braking, player.automaticDriving, player.currentSpeedLimit, player.engine, player.reverser)
 
 	get_node("../Cabin/DisplayLeft/ScreenLeft2").update_time(player.world.time)
 	get_node("../Cabin/DisplayLeft/ScreenLeft2").update_voltage(player.voltage)

--- a/src/Trains/JFR1/SpecificScriptingGrey.gd
+++ b/src/Trains/JFR1/SpecificScriptingGrey.gd
@@ -30,7 +30,7 @@ func _process(_delta: float) -> void:
 	if not is_ready:
 		is_ready = true
 		ready()
-	get_node("../Cabin/DisplayMiddle/Display").update_display(Math.speed_to_kmh(player.speed), player.technicalSoll, player.doorLeft, player.doorRight, player.doorsClosing, player.enforced_braking, player.automaticDriving, player.currentSpeedLimit, player.engine, player.reverser)
+	get_node("../Cabin/DisplayMiddle/Display").update_display(Math.speed_to_kmh(player.speed), player.technicalSoll, player.door_left.is_opened(), player.door_right.is_opened(), player.are_doors_closing(), player.enforced_braking, player.automaticDriving, player.currentSpeedLimit, player.engine, player.reverser)
 
 	get_node("../Cabin/DisplayLeft/ScreenLeft2").update_time(player.world.time)
 	get_node("../Cabin/DisplayLeft/ScreenLeft2").update_voltage(player.voltage)

--- a/src/Worlds/Tutorials/TutorialScript.gd
+++ b/src/Worlds/Tutorials/TutorialScript.gd
@@ -57,7 +57,7 @@ func basics() -> void:
 		2:
 #			message = "Great! To close the Doors, press 'o'.\n\nWhith 'i' you can open the left one,\nwith 'p' you open the right door."
 			message = TranslationServer.translate("TUTORIAL_0_1")
-			if not (player.doorRight or player.doorLeft):
+			if player.are_doors_closed():
 				next_step()
 		3:
 #			message = "Now we are able to drive.\nOur departure is at 12:00. Let's wait for the depart message in the bottom left corner."
@@ -115,7 +115,7 @@ func advanced() -> void:
 				next_step()
 		1:
 			message = TranslationServer.translate("TUTORIAL_1_6")
-			if player.current_station_node == null and not (player.doorRight or player.doorLeft):
+			if player.current_station_node == null and player.are_doors_closed():
 				next_step()
 		2:
 			message = TranslationServer.translate("TUTORIAL_1_1")
@@ -166,7 +166,7 @@ func basics_mobile_version() -> void:
 			message = TranslationServer.translate("TUTORIAL_4_3")
 			player.get_node("HUD/MobileHUD/Camera").modulate = Color(1, 1, 1, 1)
 			player.get_node("HUD/MobileHUD/DoorClose").modulate = Color(1, 0.5, 0, 1)
-			if not (player.doorRight or player.doorLeft):
+			if player.are_doors_closed():
 				next_step()
 		4:
 #			message = "Let’s abort! Use the arrow keys to drive. \n\n\tPress the up arrow key to accelerate / release the brakes.\n\tPress the down arrow key to release acceleration / apply the brakes. \n\nHint: You can see your current command at the right tachometer."

--- a/src/project.godot
+++ b/src/project.godot
@@ -114,6 +114,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://Data/Scripts/Enums/door_side.gd"
 }, {
+"base": "Reference",
+"class": "DoorState",
+"language": "GDScript",
+"path": "res://Data/Scripts/Enums/door_state.gd"
+}, {
 "base": "CameraBase",
 "class": "EditorCamera",
 "language": "GDScript",
@@ -401,6 +406,7 @@ _global_script_class_icons={
 "DebugCamera": "",
 "DistanceMonitor": "",
 "DoorSide": "",
+"DoorState": "",
 "EditorCamera": "",
 "EditorInfo": "",
 "ExportTrack": "",


### PR DESCRIPTION
Fixes #506 

This is a preview PR as Person Navigation improvements should be verified first.

To improve general design, state tracking and build a foundation for future freight trains where you might need to track door state for each wagon individually.

Using new door states system, persons will be able to:
- Approach opening doors (not yet fully opened) during on-/off-boarding.
- Transition through the doors only when doors are fully opened.
- Idle walk at the station while waiting for the train.
- Get back to the seat and choose another destination if person missed the station.
- Detect crowdy places so they not collide in a single model. 

It might be a good idea to raise a separate enhancement issue to improve the on-/off-boarding priorities.