### PR TITLE
Unselect previously selected list item to allow reselection

### DIFF
--- a/src/Editor/Modules/add_objects.gd
+++ b/src/Editor/Modules/add_objects.gd
@@ -7,6 +7,7 @@ onready var objects_menu := $"../Objects"
 
 func _on_RailLogicMenu_item_selected(index):
 	$RailLogicMenu.hide()
+	$RailLogicMenu.unselect_all()
 	if editor.selected_object_type != "Rail":
 		editor.send_message("At first you need to select a rail,\nto which you want to add the Rail Logic Element!")
 		return


### PR DESCRIPTION
Editor `RailLogicMenu` does not allow reselection.
While we can tick `Allow Reselect` property on `RailLogicMenu`, it is visually better to remove the selection