### PR TITLE
Fix Scenario Editor route renaming

### DIFF
--- a/src/Editor/Scripts/ScenarioConfiguration.gd
+++ b/src/Editor/Scripts/ScenarioConfiguration.gd
@@ -41,8 +41,6 @@ func _input(_event):
 
 
 func save():
-	if is_instance_valid(loaded_route):
-		routes[current_route] = loaded_route.duplicate(true)
 	scenario_editor.scenario_info.routes = routes.duplicate(true)
 	scenario_editor.scenario_info.rail_logic_settings = rail_logic_settings.duplicate(true)
 	scenario_editor.scenario_info.save_scenario()  # write to disk
@@ -99,11 +97,9 @@ func _on_Routes_user_selected_entry(entry_name):
 
 
 func set_current_route(route_name : String) -> void:
-	if is_instance_valid(loaded_route):
-		routes[current_route] = loaded_route.duplicate(true)
 	current_route = route_name
 	if current_route != "":
-		loaded_route = routes[current_route].duplicate(true)
+		loaded_route = routes[current_route]
 		loaded_route.connect_points()
 	update_ui_for_current_route()
 	update_scenario_map()


### PR DESCRIPTION
Fixes #514 

The cause of the problem is, that after renaming the route is readded to the list while switching to the route under the new name.

Is there any reason why a copy of the route is created when switching routes, so you always work on a copy of the route, that is only applied when you switch routes?
If not, this would be an easy solution