### PR TITLE
"Test Track": load game directly from editors

### DIFF
--- a/src/Data/Scripts/Singletons/Root.gd
+++ b/src/Data/Scripts/Singletons/Root.gd
@@ -10,8 +10,6 @@ var selected_time: int = -1 # start time of scenario in seconds
 var EasyMode: bool = true
 var mobile_version: bool = OS.has_feature("mobile")
 
-var start_menu_in_play_menu: bool = false
-
 var game_pause = {"pause_menu": false, "ingame_pause": false, "message": false}
 
 var world: Node  ## Reference to world

--- a/src/Data/UI/Pause.tscn
+++ b/src/Data/UI/Pause.tscn
@@ -73,6 +73,20 @@ margin_right = 294.0
 margin_bottom = 257.0
 text = "MENU_SETTINGS"
 
+[node name="BackToTrackEditor" type="Button" parent="CenterContainer/HBox"]
+visible = false
+margin_top = 367.0
+margin_right = 347.0
+margin_bottom = 416.0
+text = "BACK_TO_TRACK_EDITOR"
+
+[node name="BackToScenarioEditor" type="Button" parent="CenterContainer/HBox"]
+visible = false
+margin_top = 367.0
+margin_right = 385.0
+margin_bottom = 416.0
+text = "BACK_TO_SCENARIO_EDITOR"
+
 [node name="QuitMenu" type="Button" parent="CenterContainer/HBox"]
 margin_top = 261.0
 margin_right = 294.0
@@ -96,6 +110,8 @@ margin_bottom = -12.0
 [connection signal="pressed" from="CenterContainer/HBox/RestartScenario" to="." method="_on_RestartScenario_pressed"]
 [connection signal="pressed" from="CenterContainer/HBox/JumpToStation" to="." method="_on_JumpToStation_pressed"]
 [connection signal="pressed" from="CenterContainer/HBox/Settings" to="." method="_on_Settings_pressed"]
+[connection signal="pressed" from="CenterContainer/HBox/BackToTrackEditor" to="." method="_on_BackToTrackEditor_pressed"]
+[connection signal="pressed" from="CenterContainer/HBox/BackToScenarioEditor" to="." method="_on_BackToScenarioEditor_pressed"]
 [connection signal="pressed" from="CenterContainer/HBox/QuitMenu" to="." method="_on_QuitMenu_pressed"]
 [connection signal="pressed" from="CenterContainer/HBox/QuitOS" to="." method="_on_Quit_pressed"]
 [connection signal="station_index_selected" from="StationJumper" to="." method="_on_StationJumper_station_index_selected"]

--- a/src/Data/UI/main_menu.gd
+++ b/src/Data/UI/main_menu.gd
@@ -9,8 +9,6 @@ func _ready():
 	# Update GUI language directly at launch
 	jSettings.update_and_prepare_language_handling()
 
-	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
-
 	$Version.text = "Version: %s" % ProjectSettings["application/version/label"]
 	if ProjectSettings["application/version/broken"]:
 		$Version.add_color_override("font_color", Color.webmaroon)
@@ -26,11 +24,6 @@ func _ready():
 		$Feedback/VBoxContainer/HBoxContainer/OpenWebBrowser.grab_focus()
 	else:
 		$Buttons/Play.grab_focus()
-
-	if Root.start_menu_in_play_menu:
-		Root.start_menu_in_play_menu = false
-		$Feedback.hide()
-		_on_PlayFront_pressed()
 
 	updateBottmLabels()
 	Logger.log("Using version: %s" % ProjectSettings["application/version/label"])

--- a/src/Data/UI/pause.gd
+++ b/src/Data/UI/pause.gd
@@ -18,6 +18,11 @@ func _ready() -> void:
 
 
 func show() -> void:
+	if player.game_start_context == LTSPlayer.GameStartContext.ScenarioEditor:
+		$CenterContainer/HBox/BackToScenarioEditor.show()
+	elif player.game_start_context == LTSPlayer.GameStartContext.TrackEditor:
+		$CenterContainer/HBox/BackToTrackEditor.show()
+
 	$CenterContainer/HBox/Back.grab_focus()
 	.show()
 
@@ -81,7 +86,6 @@ func _on_StationJumper_station_index_selected(station_index: int) -> void:
 
 
 func _on_RestartScenario_pressed() -> void:
-	Root.reset_game_pause()
 	jEssentials.remove_all_pending_delayed_calls()
 	jAudioManager.clear_all_sounds()
 	var _unused = get_tree().reload_current_scene()
@@ -89,3 +93,12 @@ func _on_RestartScenario_pressed() -> void:
 
 func _on_Settings_pressed() -> void:
 	jSettings.popup()
+
+
+func _on_BackToTrackEditor_pressed() -> void:
+	var screenshot = Image.new().load(Root.current_track.get_base_dir().plus_file("screenshot.png"))
+	LoadingScreen.load_editor(Root.current_track.get_basename(), screenshot)
+
+
+func _on_BackToScenarioEditor_pressed() -> void:
+	get_tree().change_scene_to(load("res://Editor/Modules/scenario_editor.tscn"))

--- a/src/Data/UI/play_menu.gd
+++ b/src/Data/UI/play_menu.gd
@@ -1,5 +1,7 @@
 extends Panel
 
+export(int, "Main Menu", "Track Editor", "Scenario Editor") var context: int
+
 var selected_track: String = ""
 var selected_scenario: String = ""
 var selected_route: String = ""
@@ -30,9 +32,33 @@ func show() -> void:
 	$V/Tracks/H/ItemList.grab_focus()
 	.show()
 
+# Directly show the scenario selector for the given track.
+# Used by the "test track" feature in the track editor
+func show_scenario_selector(track: String) -> void:
+	selected_track = track
+
+	update_scenarios()
+	track_selector.hide()
+	scenario_selector.show()
+	$V/Scenarios/ItemList.grab_focus()
+	.show()
+
+# Directly show the route selector for the given track and scenario.
+# Used by the "test track" feature in the scenario editor
+func show_route_selector(track: String, scenario: String) -> void:
+	selected_track = track
+	selected_scenario = scenario
+	loaded_scenario = load(scenario)
+
+	update_routes()
+	track_selector.hide()
+	route_selector.show()
+	$V/Routes/ItemList.grab_focus()
+	.show()
+
 
 func _unhandled_input(event: InputEvent) -> void:
-	if visible and event.is_action_pressed("ui_cancel"):
+	if visible and event.is_action_released("ui_cancel"):
 		if track_selector.visible:
 			_on_Tracks_Back_pressed()
 		elif scenario_selector.visible:
@@ -71,7 +97,7 @@ func load_game():
 	Root.EasyMode = $V/Trains/H/V/EasyMode/CheckButton.pressed
 	hide()
 
-	LoadingScreen.load_world(selected_track, $V/Tracks/H/Information/V/Image.texture)
+	LoadingScreen.load_world(selected_track, $V/Tracks/H/Information/V/Image.texture, context)
 
 
 func update_tracks() -> void:
@@ -208,12 +234,16 @@ func _on_Tracks_Back_pressed() -> void:
 func _on_Scenarios_Back_pressed():
 	selected_scenario = ""
 	loaded_scenario = null
-	update_breadcrumb()
-	scenario_selector.hide()
-	track_selector.show()
 
-	if $V/Tracks/H/ItemList.get_item_count() == 1:
-		_on_Tracks_Back_pressed()
+	if context == LTSPlayer.GameStartContext.TrackEditor:
+		hide()
+	else:
+		update_breadcrumb()
+		scenario_selector.hide()
+		track_selector.show()
+
+		if $V/Tracks/H/ItemList.get_item_count() == 1:
+			_on_Tracks_Back_pressed()
 
 
 func _on_Scenarios_Select_pressed():
@@ -234,11 +264,15 @@ func _on_Scenarios_item_activated(_index):
 func _on_Routes_Back_pressed():
 	selected_route = ""
 	update_breadcrumb()
-	route_selector.hide()
-	scenario_selector.show()
 
-	if $V/Scenarios/ItemList.get_item_count() == 1:
-		_on_Scenarios_Back_pressed()
+	if context == LTSPlayer.GameStartContext.ScenarioEditor:
+		hide()
+	else:
+		route_selector.hide()
+		scenario_selector.show()
+
+		if $V/Scenarios/ItemList.get_item_count() == 1:
+			_on_Scenarios_Back_pressed()
 
 
 func _on_Routes_Select_pressed():

--- a/src/Editor/Editor.tscn
+++ b/src/Editor/Editor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=30 format=2]
+[gd_scene load_steps=31 format=2]
 
 [ext_resource path="res://Editor/Scripts/editor_camera.gd" type="Script" id=1]
 [ext_resource path="res://Editor/Scripts/Editor.gd" type="Script" id=2]
@@ -28,6 +28,7 @@
 [ext_resource path="res://Editor/ui/icons/vegetation.png" type="Texture" id=26]
 [ext_resource path="res://Editor/ui/objects_menu/add_rail_object_button.gd" type="Script" id=27]
 [ext_resource path="res://Editor/Modules/building_settings.tscn" type="PackedScene" id=28]
+[ext_resource path="res://Data/UI/play_menu.tscn" type="PackedScene" id=29]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 8.0
@@ -691,6 +692,14 @@ dialog_autowrap = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="PlayMenu" parent="EditorHUD" instance=ExtResource( 29 )]
+visible = false
+margin_left = 12.0
+margin_top = 12.0
+margin_right = -12.0
+margin_bottom = -12.0
+context = 1
 
 [node name="Landscape" type="Spatial" parent="."]
 

--- a/src/Editor/Modules/scenario_editor.tscn
+++ b/src/Editor/Modules/scenario_editor.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://Editor/Modules/scenario_configuration.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Editor/Scripts/scenario_editor.gd" type="Script" id=2]
 [ext_resource path="res://Editor/Modules/scenario_map.tscn" type="PackedScene" id=3]
 [ext_resource path="res://Data/UI/blur.tres" type="Material" id=4]
+[ext_resource path="res://Data/UI/play_menu.tscn" type="PackedScene" id=5]
 [ext_resource path="res://Data/UI/styles/complete_menu.tres" type="Theme" id=8]
 [ext_resource path="res://Editor/Modules/Content_Selector.tscn" type="PackedScene" id=9]
 [ext_resource path="res://Data/UI/styles/button_both.tres" type="Theme" id=10]
@@ -282,6 +283,14 @@ margin_top = 44.0
 margin_right = 201.0
 margin_bottom = 64.0
 text = "Update"
+
+[node name="PlayMenu" parent="CanvasLayer" instance=ExtResource( 5 )]
+visible = false
+margin_left = 12.0
+margin_top = 12.0
+margin_right = -12.0
+margin_bottom = -12.0
+context = 2
 
 [node name="ScenarioMap" parent="." instance=ExtResource( 3 )]
 

--- a/src/Editor/Scripts/Editor.gd
+++ b/src/Editor/Scripts/Editor.gd
@@ -5,15 +5,12 @@ signal selected_object_changed(new_object, type_string)
 
 
 var editor_directory: String = ""
-var content: ModContentDefinition
 var authors: Authors
 var editor_info: EditorInfo = null
 ## Track path without file extension
 var current_track_path := "" setget set_current_track_path
 ## Track name is the string after the last /
 var current_track_name := ""
-## Base path of the mod that contains the world
-var mod_path := ""
 
 var selected_object: Node = null
 var selected_object_type: String = ""
@@ -1054,25 +1051,16 @@ func get_current_ground_position() -> Vector3:
 	return position
 
 
-func test_track_pck() -> void:
-	if OS.has_feature("editor"):
-		send_message("Can't test tracks if runs Libre TrainSim using the Godot Editor. " \
-				+ "Please use a build of Libre TrainSim to test tracks. ")
-		return
-
+func test_track() -> void:
 	if ContentLoader.get_scenarios_for_track(current_track_path).size() == 0:
 		send_message("Cannot test the track! Please create a scenario using the scenario editor.")
 		return
 
-	export_mod()
+	save_world(false)
 
-	if !ProjectSettings.load_resource_pack("user://addons/%s/%s.pck" % [content.unique_name, content.unique_name]):
-		Logger.warn("Can't load content pack!", self)
-		send_message("Can't load content pack!")
-		return
-	ContentLoader.append_content_to_global_repo(content)
-	Root.start_menu_in_play_menu = true
-	LoadingScreen.load_main_menu()
+	$EditorHUD/PlayMenu.show_scenario_selector( \
+		current_track_path.plus_file(current_track_name + ".tscn")
+	)
 
 
 func export_mod() -> void:
@@ -1092,7 +1080,7 @@ func _on_ExportTrack_pressed() -> void:
 
 
 func _on_TestTrack_pressed() -> void:
-	test_track_pck()
+	test_track()
 
 
 func send_message(message: String) -> void:

--- a/src/Editor/Scripts/editor_configuration.gd
+++ b/src/Editor/Scripts/editor_configuration.gd
@@ -121,8 +121,7 @@ func _on_TracksList_user_pressed_action(entry_names):
 		texture = null
 
 	Root.current_track = entry_names[0]
-	LoadingScreen.load_editor(entry_names[0], tracks[entry_names[0]][0], \
-			tracks[entry_names[0]][1], texture)
+	LoadingScreen.load_editor(entry_names[0], texture)
 
 
 func _on_TracksList_user_removed_entries(entry_names):

--- a/src/Editor/Scripts/scenario_editor.gd
+++ b/src/Editor/Scripts/scenario_editor.gd
@@ -27,6 +27,11 @@ func _ready():
 	pause_menu.connect("visibility_changed", self, "_on_Pause_visibility_changed")
 
 
+func _enter_tree() -> void:
+	Root.Editor = true
+	Root.scenario_editor = true
+
+
 func _exit_tree() -> void:
 	Root.Editor = false
 	Root.scenario_editor = false
@@ -50,10 +55,10 @@ func _unhandled_input(event):
 		$CanvasLayer/Message.hide()
 		get_tree().set_input_as_handled()
 
-	if pause_menu.visible and (event.is_action_pressed("pause") or event.is_action_pressed("ui_cancel")):
+	if pause_menu.visible and (event.is_action_released("pause") or event.is_action_released("ui_cancel")):
 		pause_menu.visible = false
 		get_tree().set_input_as_handled()
-	elif event.is_action_pressed("pause"):
+	elif event.is_action_released("pause"):
 		pause_menu.visible = true
 		get_tree().set_input_as_handled()
 
@@ -105,7 +110,8 @@ func run_map_updater(delta: float):
 
 func _on_TestTrack_pressed():
 	pause_menu.hide()
-	test_track_pck()
+	save_scenario()
+	test_track()
 
 
 func _on_ExportTrack_pressed():
@@ -117,25 +123,11 @@ func save_scenario():
 	$CanvasLayer/ScenarioConfiguration.save()
 
 
-func test_track_pck() -> void:
-	#if OS.has_feature("editor"):
-	#	show_message("Can't test tracks if runs Libre TrainSim using the Godot Editor. " \
-	#			+ "Please use a build of Libre TrainSim to test tracks. ")
-	#	return
-
-	if ContentLoader.get_scenarios_for_track(current_track_path).size() == 0:
-		show_message("Cannot test the track! Please create a scenario.")
-		return
-
-	export_mod()
-
-	if !ProjectSettings.load_resource_pack("user://addons/%s/%s.pck" % [content.unique_name, content.unique_name]):
-		Logger.warn("Can't load content pack!", self)
-		show_message("Can't load content pack!")
-		return
-	ContentLoader.append_content_to_global_repo(content)
-	Root.start_menu_in_play_menu = true
-	LoadingScreen.load_main_menu()
+func test_track() -> void:
+	$CanvasLayer/PlayMenu.show_route_selector( \
+		current_track_path.plus_file(current_track_name + ".tscn"), \
+		scenario_info.resource_path \
+	)
 
 
 func export_mod() -> void:

--- a/src/Editor/Scripts/scenario_editor_selection.gd
+++ b/src/Editor/Scripts/scenario_editor_selection.gd
@@ -104,8 +104,6 @@ func _on_scenarioList_user_pressed_action(entry_names):
 	var scenarios_folder: String = selected_track.get_base_dir().plus_file("scenarios")
 	var entry_name = entry_names[0]
 	Root.current_scenario = scenarios_folder.plus_file(entry_name + ".tres")
-	Root.Editor = true
-	Root.scenario_editor = true
 	get_tree().change_scene_to(load("res://Editor/Modules/scenario_editor.tscn"))
 
 

--- a/src/Translations/Ingame.csv
+++ b/src/Translations/Ingame.csv
@@ -4,6 +4,8 @@ BACK,Back,Zurück,Indietro,戻る,Wróć,Назад,Volver,Назад,Retour
 QUIT_TO_MENU,Quit to Menu,Beenden und zum Hauptmenü,Torna al menu,終了してメニューに戻る,Wyjdź do Menu,Вийти в меню,Salir al Menú,Главно меню,Quitter vers le Menu
 EXIT_GAME,Exit game,Spiel beenden,Esci dal gioco,終了してOSに戻る,Wyjdź do Systemu,Вийти з гри,Salir al SO,Изход,Quitter vers le bureau
 RESTART_SCENARIO,Restart scenario,Szenario neustarten,Riavvia scenario,,,,Reiniciar escenario,Рестартиране на направлението,Redémarrer le scénario
+BACK_TO_TRACK_EDITOR,Back to the track editor,Zurück zum Streckeneditor,,,,,,,Retour à l’éditeur de parcours
+BACK_TO_SCENARIO_EDITOR,Back to the scenario editor,Zurück zum Szenarioeditor,,,,,,,Retour à l’éditeur de scénario
 OK,OK,Okay,OK,了解,OK,Добре,OK,ОК,OK
 STARTING_SIMULATION,Starting Simulation…,Starte Simulation…,Avvio simulazione…,,,,Comenzando Simulación,Стартиране на симулацията…,Démarrer la simulation
 ,,,,,,,,,

--- a/src/Translations/MainMenu.csv
+++ b/src/Translations/MainMenu.csv
@@ -169,8 +169,8 @@ SAVE_AND_EXIT,Save and exit,Speichern und beenden,Salva ed esci,,,,Guardar y sal
 EXIT_WITHOUT_SAVING,Exit without saving,Beenden ohne zu speichern,Esci senza salvare,,,,Salir sin guardar,Излизане без записване,Quitter sans sauvegarder
 SAVE,Save,Speichern,Salva,,,,,Записване,Sauvegarder
 ,,,,,,,,,
-TRACK_EDITOR,Track Editor,Strecken-Editor,Editor tracciato,,,,Editor de vías,Редактор на линиите,Éditeur de parcours
-SCENARIO_EDITOR,Scenario Editor,Szenario-Editor,Editor scenario,,,,Editor de escenarios,Редактор на направленията,Éditeur de scénario
+TRACK_EDITOR,Track Editor,Streckeneditor,Editor tracciato,,,,Editor de vías,Редактор на линиите,Éditeur de parcours
+SCENARIO_EDITOR,Scenario Editor,Szenarioeditor,Editor scenario,,,,Editor de escenarios,Редактор на направленията,Éditeur de scénario
 SELECT,Select,Auswählen,Seleziona,,,,Seleccionar,Избиране,Sélectionner
 PLAY,Play,Spielen,Gioca,,,,Jugar,Начало,Jouer
 CREATE,Create,Erstellen,Crea,,,,Crear,Създаване,Créer


### PR DESCRIPTION
Resolves #187 

When pressing "Test Track" in scenario or track editor open the play menu with the scenario or route selector and then directly load the game, instead of exporting it and letting the user load it manually from the main menu.

<b> Note to reviewers: </b>
It happened a few times, that the game froze on "Starting Simulation...". I tried different conditions, but I couldn't reproduce it. It's likely that it's because of broken saves I produced while developing, but if it happens to you, too it may also be a bug in this PR.
\- Edit: This didn't happen for a long time now, so it is was likely just broken saves