### PR TITLE
Fix create new track

### DIFF
--- a/src/Data/Modules/World-Pattern.tscn
+++ b/src/Data/Modules/World-Pattern.tscn
@@ -8,6 +8,9 @@
 
 [node name="World" type="Spatial"]
 script = ExtResource( 1 )
+__meta__ = {
+"chunk_version": 2
+}
 
 [node name="DirectionalLight" parent="." instance=ExtResource( 2 )]
 

--- a/src/Editor/Scripts/Editor.gd
+++ b/src/Editor/Scripts/Editor.gd
@@ -157,6 +157,8 @@ func _port_v1_to_v2_chunks() -> void:
 	# Merge possible duplicates
 	for chunk_position in chunks:
 		if chunks[chunk_position].size() == 1:
+			chunks[chunk_position][0].name = ChunkManager.chunk_to_string(chunk_position)
+			chunk_manager.loader._loaded_chunks.append(chunks[chunk_position][0].name)
 			continue
 
 		var best_fit: int = 0


### PR DESCRIPTION
Fix #530 

- Add the `chunk_version` metadata (with the value 2) to the world pattern, so the Editor doesn't try to port it
- Fix the failing assert when porting a track, that occurs because after porting a chunk is only added to the  `_loaded_chunks` of the Chunk Loader  when there are duplicates for the chunk coordinates (as a result of the porting)