### PR TITLE
fix saving on chunk_0_0 does not load chunks after saving

### DIFF
--- a/src/Data/Scripts/chunk_manager.gd
+++ b/src/Data/Scripts/chunk_manager.gd
@@ -257,8 +257,7 @@ func resume_chunking():
 	assert(Root.Editor)
 
 	set_process(true)
-	loader.set_process(true)
-	if active_chunk:
+	if active_chunk != null:
 		loader.load_chunks(get_chunks(active_chunk, ProjectSettings["game/gameplay/chunk_load_distance"]))
 
 

--- a/src/Editor/Scripts/Editor.gd
+++ b/src/Editor/Scripts/Editor.gd
@@ -942,6 +942,7 @@ func save_world(send_message: bool = true) -> void:
 	if ResourceSaver.save(current_track_path.plus_file("editor_info.tres"), editor_info) != OK:
 		Logger.warn("Failed to save editor info meta data.", self)
 
+	$World.chunk_manager.active_chunk = $World.chunk_manager.position_to_chunk(camera.global_transform.origin)
 	$World.chunk_manager.resume_chunking()
 
 	if send_message:


### PR DESCRIPTION
The problem was:  
if you are on Chunk_0_0 and save your map, the chunks would unload and save, but then they would not load afterwards!

The problem was caused by `if active_chunk`. This does not do an explicit NULL check, but instead does an `is_falsy` check. For example, False is falsy, 0 is falsy, "" is falsy, null is falsy, and... `Vector3(0,0,0)` is falsy (that's chunk_0_0!) 😦 

Also removed the `loader.set_process(true)` because that is not necessary, the `loader.load_chunks()` call will already do that. (besides, `_process` just disables itself if no chunks need to be loaded!)

Also explicitly set the active chunk in the save_world method. I don't think this was necessary, but better save than sorry? 😅 