### PR TITLE
Some gizmo improvements

### DIFF
--- a/src/Editor/Editor.tscn
+++ b/src/Editor/Editor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=31 format=2]
+[gd_scene load_steps=33 format=2]
 
 [ext_resource path="res://Editor/Scripts/editor_camera.gd" type="Script" id=1]
 [ext_resource path="res://Editor/Scripts/Editor.gd" type="Script" id=2]
@@ -29,6 +29,7 @@
 [ext_resource path="res://Editor/ui/objects_menu/add_rail_object_button.gd" type="Script" id=27]
 [ext_resource path="res://Editor/Modules/building_settings.tscn" type="PackedScene" id=28]
 [ext_resource path="res://Data/UI/play_menu.tscn" type="PackedScene" id=29]
+[ext_resource path="res://Editor/ui/object_transform.gd" type="Script" id=30]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 8.0
@@ -49,6 +50,13 @@ expand_margin_top = 2.0
 expand_margin_bottom = 2.0
 shadow_size = 1
 anti_aliasing = false
+
+[sub_resource type="StyleBoxFlat" id=2]
+content_margin_left = 7.0
+content_margin_right = 7.0
+content_margin_top = 7.0
+content_margin_bottom = 7.0
+bg_color = Color( 0.145098, 0.145098, 0.164706, 1 )
 
 [node name="Editor" type="Spatial"]
 script = ExtResource( 2 )
@@ -181,9 +189,6 @@ margin_right = -6.0
 margin_bottom = -1.0
 size_flags_horizontal = 3
 size_flags_vertical = 4
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="Label" type="Label" parent="EditorHUD/ObjectName/Name"]
 margin_top = 5.0
@@ -232,134 +237,104 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="ObjectTransform" type="Control" parent="EditorHUD"]
+[node name="ObjectTransform" type="PanelContainer" parent="EditorHUD"]
 visible = false
 anchor_left = 0.5
 anchor_right = 0.5
 margin_left = -375.0
 margin_top = 30.0
 margin_right = 375.0
-margin_bottom = 64.0
-
-[node name="Panel" type="Panel" parent="EditorHUD/ObjectTransform"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = -1.0
+margin_bottom = 84.0
+custom_styles/panel = SubResource( 2 )
+script = ExtResource( 30 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="EditorHUD/ObjectTransform"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 6.0
+margin_left = 7.0
 margin_top = 7.0
-margin_right = -5.0
-margin_bottom = -3.0
-
-[node name="Label" type="Label" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_top = 5.0
-margin_right = 15.0
-margin_bottom = 19.0
-text = "x: "
+margin_right = 743.0
+margin_bottom = 47.0
 
 [node name="x" type="SpinBox" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 19.0
-margin_right = 108.0
-margin_bottom = 24.0
+margin_right = 87.0
+margin_bottom = 40.0
 size_flags_horizontal = 3
 min_value = -1000.0
 max_value = 1000.0
-step = 0.0
+step = 0.1
 allow_greater = true
 allow_lesser = true
-
-[node name="Label2" type="Label" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 112.0
-margin_top = 5.0
-margin_right = 127.0
-margin_bottom = 19.0
-text = "y: "
+prefix = "x:"
+suffix = "m"
 
 [node name="y" type="SpinBox" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 131.0
-margin_right = 221.0
-margin_bottom = 24.0
+margin_left = 91.0
+margin_right = 178.0
+margin_bottom = 40.0
 size_flags_horizontal = 3
-min_value = -1000.0
-max_value = 1000.0
-step = 0.0
+min_value = -10.0
+step = 0.1
 allow_greater = true
 allow_lesser = true
-
-[node name="Label3" type="Label" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 225.0
-margin_top = 5.0
-margin_right = 240.0
-margin_bottom = 19.0
-text = "z: "
+prefix = "y:"
+suffix = "m"
 
 [node name="z" type="SpinBox" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 244.0
-margin_right = 334.0
-margin_bottom = 24.0
+margin_left = 182.0
+margin_right = 270.0
+margin_bottom = 40.0
 size_flags_horizontal = 3
 min_value = -1000.0
 max_value = 1000.0
-step = 0.0
+step = 0.1
 allow_greater = true
 allow_lesser = true
-
-[node name="Label4" type="Label" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 338.0
-margin_top = 5.0
-margin_right = 375.0
-margin_bottom = 19.0
-text = "x rot: "
+prefix = "z:"
+suffix = "m"
 
 [node name="x_rot" type="SpinBox" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 379.0
-margin_right = 469.0
-margin_bottom = 24.0
+margin_left = 274.0
+margin_right = 361.0
+margin_bottom = 40.0
 size_flags_horizontal = 3
-min_value = -1000.0
-max_value = 1000.0
-step = 0.0
+min_value = -360.0
+max_value = 360.0
+step = 0.1
 allow_greater = true
 allow_lesser = true
-
-[node name="Label5" type="Label" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 473.0
-margin_top = 5.0
-margin_right = 510.0
-margin_bottom = 19.0
-text = "y rot: "
+prefix = "rX"
+suffix = "°"
 
 [node name="y_rot" type="SpinBox" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 514.0
-margin_right = 604.0
-margin_bottom = 24.0
+margin_left = 365.0
+margin_right = 452.0
+margin_bottom = 40.0
 size_flags_horizontal = 3
-min_value = -1000.0
-max_value = 1000.0
-step = 0.0
+min_value = -360.0
+max_value = 360.0
+step = 0.1
 allow_greater = true
 allow_lesser = true
-
-[node name="Label6" type="Label" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 608.0
-margin_top = 5.0
-margin_right = 645.0
-margin_bottom = 19.0
-text = "z rot: "
+prefix = "rY:"
+suffix = "°"
 
 [node name="z_rot" type="SpinBox" parent="EditorHUD/ObjectTransform/HBoxContainer"]
-margin_left = 649.0
-margin_right = 739.0
-margin_bottom = 24.0
+margin_left = 456.0
+margin_right = 544.0
+margin_bottom = 40.0
 size_flags_horizontal = 3
-min_value = -1000.0
-max_value = 1000.0
-step = 0.0
+min_value = -360.0
+max_value = 360.0
+step = 0.1
 allow_greater = true
 allow_lesser = true
+prefix = "rZ:"
+suffix = "°"
+
+[node name="Local" type="CheckButton" parent="EditorHUD/ObjectTransform/HBoxContainer"]
+margin_left = 548.0
+margin_right = 736.0
+margin_bottom = 40.0
+text = "Local Transforms"
 
 [node name="Objects" type="PanelContainer" parent="EditorHUD"]
 anchor_bottom = 1.0
@@ -403,8 +378,7 @@ follow_focus = true
 scroll_horizontal_enabled = false
 
 [node name="Content" type="VBoxContainer" parent="EditorHUD/Objects/MarginContainer/Content/ScrollContainer"]
-margin_right = 185.0
-margin_bottom = 343.0
+margin_right = 173.0
 hint_tooltip = "- Use shift to select multiple objects.
 - Right-click deselects all selected objects.
 - Shift+scroll wheel chooses a random object of the selected objects."
@@ -715,6 +689,8 @@ highlight_color = Color( 1, 1, 0, 1 )
 [node name="WorldCusor" type="Spatial" parent="."]
 script = ExtResource( 21 )
 
+[connection signal="selected_object_changed" from="." to="EditorHUD" method="_on_selected_object_changed"]
+[connection signal="selected_object_changed" from="." to="EditorHUD/ObjectTransform" method="_on_selected_object_changed"]
 [connection signal="selected_object_changed" from="." to="EditorHUD/AddObjects" method="_on_selected_object_changed"]
 [connection signal="selected_object_changed" from="." to="EditorHUD/AddObjects/HBoxContainer/AddRailObject" method="_on_selected_object_changed"]
 [connection signal="pressed" from="EditorHUD/GlobalMenu/ShowSettingsButton" to="EditorHUD" method="_on_ShowSettings_pressed"]
@@ -728,12 +704,13 @@ script = ExtResource( 21 )
 [connection signal="pressed" from="EditorHUD/ObjectName/Name/Rename" to="EditorHUD" method="_on_CurrentObjectRename_pressed"]
 [connection signal="pressed" from="EditorHUD/ObjectName/Name/Delete" to="EditorHUD" method="_on_DeleteCurrentObject_pressed"]
 [connection signal="pressed" from="EditorHUD/ObjectName/Name/Duplicate" to="EditorHUD" method="_on_DuplicateObject_pressed"]
-[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/x" to="EditorHUD" method="_on_x_value_changed"]
-[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/y" to="EditorHUD" method="_on_y_value_changed"]
-[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/z" to="EditorHUD" method="_on_z_value_changed"]
-[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/x_rot" to="EditorHUD" method="_on_x_rot_value_changed"]
-[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/y_rot" to="EditorHUD" method="_on_y_rot_value_changed"]
-[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/z_rot" to="EditorHUD" method="_on_z_rot_value_changed"]
+[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/x" to="EditorHUD/ObjectTransform" method="_on_x_value_changed"]
+[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/y" to="EditorHUD/ObjectTransform" method="_on_y_value_changed"]
+[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/z" to="EditorHUD/ObjectTransform" method="_on_z_value_changed"]
+[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/x_rot" to="EditorHUD/ObjectTransform" method="_on_x_rot_value_changed"]
+[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/y_rot" to="EditorHUD/ObjectTransform" method="_on_y_rot_value_changed"]
+[connection signal="value_changed" from="EditorHUD/ObjectTransform/HBoxContainer/z_rot" to="EditorHUD/ObjectTransform" method="_on_z_rot_value_changed"]
+[connection signal="toggled" from="EditorHUD/ObjectTransform/HBoxContainer/Local" to="EditorHUD/ObjectTransform" method="_on_local_toggled"]
 [connection signal="object_added" from="EditorHUD/Objects" to="." method="_on_object_added"]
 [connection signal="text_changed" from="EditorHUD/Objects/MarginContainer/Content/Search" to="EditorHUD/Objects" method="_on_search_text_changed"]
 [connection signal="mouse_entered" from="EditorHUD/Objects/Overlay/Filters" to="EditorHUD/Objects/Overlay/Filters" method="_on_mouse_entered"]

--- a/src/Editor/Scripts/Editor.gd
+++ b/src/Editor/Scripts/Editor.gd
@@ -889,7 +889,8 @@ func save_world(send_message: bool = true) -> void:
 
 	# move newly created buildings from world to chunks
 	for building in $World/Buildings.get_children():
-		var chunk_pos = $World.chunk_manager.position_to_chunk(building.global_transform.origin)
+		var position := building.global_transform.origin as Vector3
+		var chunk_pos = $World.chunk_manager.position_to_chunk(position)
 		var chunk_name = $World.chunk_manager.chunk_to_string(chunk_pos)
 
 		var chunk = $World/Chunks.find_node(chunk_name)
@@ -899,6 +900,7 @@ func save_world(send_message: bool = true) -> void:
 		$World/Buildings.remove_child(building)
 		chunk.get_node("Buildings").add_child(building)
 		building.owner = chunk
+		building.global_translation = position
 
 	$World.chunk_manager.save_and_unload_all_chunks()
 	assert($World/Chunks.get_child_count() == 0)

--- a/src/Editor/Scripts/Editor.gd
+++ b/src/Editor/Scripts/Editor.gd
@@ -622,7 +622,7 @@ func handle_drag_mode() -> void:
 	var mouse_pos_3d := plane.intersects_ray(camera.project_ray_origin(mouse_pos), camera.project_ray_normal(mouse_pos))
 	if mouse_pos_3d != null:
 		selected_object.calculate_from_start_end(mouse_pos_3d)  # update rail
-		provide_settings_for_selected_object()  # update ui
+		$EditorHUD.provide_settings_for_selected_object()  # update ui, but why?
 
 	# wait for update of overlapping areas, else we can never un-snap
 	# yes, this really needs idle_frame, won't work otherwise
@@ -808,7 +808,6 @@ func clear_selected_object() -> void:
 		if selected_object_type == "Building":
 			$EditorHUD/Settings/TabContainer/BuildingSettings.set_mesh(null)
 		if selected_object_type in ["Building", "Rail"]:
-			$EditorHUD.hide_current_object_transform()
 			for child in selected_object.get_children():
 				if child.is_in_group("Gizmo"):
 					child.queue_free()
@@ -819,7 +818,6 @@ func clear_selected_object() -> void:
 
 	selected_object = null
 	selected_object_type = ""
-	$EditorHUD.clear_current_object_name()
 
 
 func get_type_of_object(object: Node) -> String:
@@ -845,26 +843,6 @@ func object_has_active_gizmo(object: Node) -> bool:
 			if node.any_axis_active():
 				return true
 	return false
-
-
-func provide_settings_for_selected_object() -> void:
-	match selected_object_type:
-		"Rail":
-			$EditorHUD/Settings/TabContainer/RailAttachments.update_selected_rail(selected_object)
-			$EditorHUD/Settings/TabContainer/RailBuilder.update_selected_rail(selected_object)
-			$EditorHUD.show_rail_settings()
-		"Building":
-			var children := get_children_of_type_recursive(selected_object, MeshInstance)
-			var mesh: ArrayMesh = children[0].mesh as ArrayMesh if children.size() > 0 else null
-			$EditorHUD/Settings/TabContainer/BuildingSettings.set_mesh(mesh, children[0])
-			$EditorHUD.show_building_settings()
-		"Signal":
-			$EditorHUD/Settings/TabContainer/RailLogic.set_rail_logic(selected_object)
-			$EditorHUD.show_signal_settings()
-		_:
-			$EditorHUD/Settings/TabContainer/RailAttachments.update_selected_rail(null)
-			$EditorHUD/Settings/TabContainer/RailBuilder.update_selected_rail(null)
-	$EditorHUD.update_ShowSettingsButton()
 
 
 ## Should be used, if world is loaded into scene.
@@ -952,12 +930,6 @@ func _on_SaveWorldButton_pressed() -> void:
 	save_world()
 
 
-func rename_selected_object(new_name: String) -> void:
-	Root.name_node_appropriate(selected_object, new_name, selected_object.get_parent())
-	$EditorHUD.set_current_object_name(selected_object.name)
-	provide_settings_for_selected_object()
-
-
 func delete_selected_object() -> void:
 	if selected_object_type == "Rail":
 		$World.chunk_manager.remove_rail(selected_object)
@@ -978,18 +950,13 @@ func set_selected_object(object: Node) -> void:
 		vi.set_layer_mask_bit(1, true)
 
 	selected_object = object
-	$EditorHUD.set_current_object_name(selected_object.name)
 	selected_object_type = get_type_of_object(selected_object)
 
 	if selected_object_type == "Building":
 		selected_object.add_child(preload("res://Editor/Modules/Gizmo.tscn").instance())
-		$EditorHUD.show_current_object_transform()
-	if selected_object_type == "Rail":
-		if selected_object.manual_moving:
-			selected_object.add_child(preload("res://Editor/Modules/Gizmo.tscn").instance())
-			$EditorHUD.show_current_object_transform()
+	if selected_object_type == "Rail" and selected_object.manual_moving:
+		selected_object.add_child(preload("res://Editor/Modules/Gizmo.tscn").instance())
 
-	provide_settings_for_selected_object()
 	emit_signal("selected_object_changed", object, selected_object_type)
 
 

--- a/src/Editor/Scripts/Gizmo.gd
+++ b/src/Editor/Scripts/Gizmo.gd
@@ -31,67 +31,67 @@ var local_mode := false setget set_local_mode
 func _unhandled_input(event: InputEvent) -> void:
 	var mm := event as InputEventMouseMotion
 	if mm != null and (x_active or y_active or z_active):
-		
+
 		# The difference to the start position is calculated by using the law of sines
 		# on the triangle between the origin of the camera, the position where the gizmo is grabbed
 		# and the position where the grabbed point is moved to
-		
+
 		var direction := Vector3(x_active, y_active, z_active)
 
 		if local_mode:
 			direction = (global_transform.basis * direction).normalized()
 
 		var camera := get_viewport().get_camera()
-		
+
 		var grab_position_on_screen := camera.unproject_position(grab_position)
 		var direction_on_screen := (camera.unproject_position(grab_position + direction) - grab_position_on_screen).normalized()
-		
+
 		# If the axis is dragged in the negative direction
 		if (mm.position - grab_position_on_screen).dot(direction_on_screen) < 0:
 			direction *= -1
-		
+
 		# The object has to be moved to the perpendicular of the mouse position on the axis on screen
 		# We calculate this point:
 		var perpendicular_screen_point := (mm.position - grab_position_on_screen).dot(direction_on_screen) * direction_on_screen + grab_position_on_screen;
-		
+
 		var cam_to_grab_position := grab_position - camera.global_transform.origin
 		var cam_to_new_position := camera.project_ray_normal(perpendicular_screen_point)
-		
+
 		# The angle at the camera between the vectors to the grab position and the new position
 		var angle_grab_cam_new := cam_to_grab_position.angle_to(cam_to_new_position)
 		# The angle at the object between the vectors to the camera and the new position
 		var angle_cam_object_new := PI - cam_to_grab_position.angle_to(direction)
-		
+
 		# Limit if the moused is moved beyond the limits of the axis
 		if angle_grab_cam_new + angle_cam_object_new >= PI:
 			angle_grab_cam_new = PI - angle_cam_object_new - 0.01
-		
+
 		# We get the diff with the law of sines
 		var diff := cam_to_grab_position.length() \
 			/ sin(PI - angle_grab_cam_new - angle_cam_object_new) \
 			* sin(angle_grab_cam_new)
-		
+
 		get_parent().global_translation = start_position + diff * direction
-	
+
 	elif mm != null and (x_rot_active or y_rot_active or z_rot_active):
-		
+
 		# The player rotates the object by circeling his mouse pointer around the gizmo
-		
+
 		var camera := get_viewport().get_camera()
-		
+
 		var axis := \
 			Vector3(1, 0, 0) if x_rot_active else \
 			Vector3(0, 1, 0) if y_rot_active else \
 			Vector3(0, 0, 1)
-		
+
 		var plane := Plane(axis, get_parent().translation.dot(axis))
-		
+
 		var ray_old_mouse_position := camera.project_ray_normal(mm.position - event.relative)
 		var ray_new_mouse_position := camera.project_ray_normal(mm.position)
-		
+
 		var intersection_old := plane.intersects_ray(camera.translation, ray_old_mouse_position)
 		var intersection_new := plane.intersects_ray(camera.translation, ray_new_mouse_position)
-		
+
 		# Do nothing when the mouse pointer doesn't hover over the plane
 		if intersection_old != null and intersection_new != null:
 			var diff: float = (intersection_old - get_parent().translation).signed_angle_to(intersection_new - get_parent().translation, axis)
@@ -99,9 +99,9 @@ func _unhandled_input(event: InputEvent) -> void:
 
 	elif mm != null and not any_axis_active():
 		_reset_colors()
-		
+
 		var result = _raycast_on_gizmo_layer()
-		
+
 		if result.has("collider"):
 			match result["collider"].name:
 				"x-axis":
@@ -120,7 +120,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	elif event is InputEventMouseButton and event.button_index == BUTTON_LEFT:
 		if event.pressed:
 			var result = _raycast_on_gizmo_layer()
-			
+
 			if result.has("collider"):
 				start_position = get_parent().global_transform.origin
 				grab_position = result["position"]
@@ -137,7 +137,7 @@ func _unhandled_input(event: InputEvent) -> void:
 						y_rot_active = true
 					"z-rot":
 						z_rot_active = true
-		
+
 		elif any_axis_active():
 			# Deactivate all axes
 			x_active = false
@@ -146,7 +146,7 @@ func _unhandled_input(event: InputEvent) -> void:
 			x_rot_active = false
 			y_rot_active = false
 			z_rot_active = false
-			
+
 			_reset_colors()
 
 
@@ -171,12 +171,12 @@ func set_local_mode(is_local: bool) -> void:
 
 func _raycast_on_gizmo_layer() -> Dictionary:
 	var camera := get_viewport().get_camera()
-	
+
 	var ray_length := 1000
 	var mouse_pos := get_viewport().get_mouse_position()
 	var from := camera.project_ray_origin(mouse_pos)
 	var to := from + camera.project_ray_normal(mouse_pos) * ray_length
-	
+
 	var space_state := get_world().get_direct_space_state()
 	return space_state.intersect_ray(from, to, [  ], 0b10)
 

--- a/src/Editor/Scripts/Gizmo.gd
+++ b/src/Editor/Scripts/Gizmo.gd
@@ -65,7 +65,7 @@ func _unhandled_input(event: InputEvent) -> void:
 			/ sin(PI - angle_grab_cam_new - angle_cam_object_new) \
 			* sin(angle_grab_cam_new)
 		
-		get_parent().translation = start_position + diff * direction
+		get_parent().global_translation = start_position + diff * direction
 	
 	elif mm != null and (x_rot_active or y_rot_active or z_rot_active):
 		

--- a/src/Editor/Scripts/Gizmo.gd
+++ b/src/Editor/Scripts/Gizmo.gd
@@ -1,3 +1,4 @@
+class_name Gizmo
 extends Spatial
 
 
@@ -25,6 +26,8 @@ var z_rot_hovered := false
 var start_position: Vector3
 var grab_position: Vector3
 
+var local_mode := false setget set_local_mode
+
 func _unhandled_input(event: InputEvent) -> void:
 	var mm := event as InputEventMouseMotion
 	if mm != null and (x_active or y_active or z_active):
@@ -34,7 +37,10 @@ func _unhandled_input(event: InputEvent) -> void:
 		# and the position where the grabbed point is moved to
 		
 		var direction := Vector3(x_active, y_active, z_active)
-		
+
+		if local_mode:
+			direction = (global_transform.basis * direction).normalized()
+
 		var camera := get_viewport().get_camera()
 		
 		var grab_position_on_screen := camera.unproject_position(grab_position)
@@ -146,13 +152,21 @@ func _unhandled_input(event: InputEvent) -> void:
 
 func _process(delta: float) -> void:
 	# Keep the gizmo unrotated while his parent rotates
-	global_rotation = Vector3(0, 0, 0)
+	if local_mode:
+		rotation = Vector3(0, 0, 0)
+	else:
+		global_rotation = Vector3(0, 0, 0)
 	# Make the gizmo always have the same size on screen
 	scale = Vector3(0.005, 0.005, 0.005) * (get_viewport().get_camera().global_translation - global_translation).length()
 
 
 func any_axis_active() -> bool:
 	return x_active or y_active or z_active or x_rot_active or y_rot_active or z_rot_active
+
+
+func set_local_mode(is_local: bool) -> void:
+	local_mode = is_local
+
 
 
 func _raycast_on_gizmo_layer() -> Dictionary:

--- a/src/Editor/ui/object_transform.gd
+++ b/src/Editor/ui/object_transform.gd
@@ -1,0 +1,97 @@
+class_name ObjectTransform
+extends PanelContainer
+
+
+var local_mode := false
+var selected_object: Node
+var selected_type := ""
+
+
+func _process(_delta: float) -> void:
+	update_values()
+
+
+func update_values():
+	if not visible:
+		return
+	if not is_instance_valid(selected_object):
+		hide()
+		return
+	if local_mode:
+		$HBoxContainer/x.value = selected_object.translation.x
+		$HBoxContainer/y.value = selected_object.translation.y
+		$HBoxContainer/z.value = selected_object.translation.z
+		$HBoxContainer/x_rot.value = rad2deg(selected_object.rotation.x)
+		$HBoxContainer/y_rot.value = rad2deg(selected_object.rotation.y)
+		$HBoxContainer/z_rot.value = rad2deg(selected_object.rotation.z)
+	else:
+		$HBoxContainer/x.value = selected_object.global_translation.x
+		$HBoxContainer/y.value = selected_object.global_translation.y
+		$HBoxContainer/z.value = selected_object.global_translation.z
+		$HBoxContainer/x_rot.value = rad2deg(selected_object.global_rotation.x)
+		$HBoxContainer/y_rot.value = rad2deg(selected_object.global_rotation.y)
+		$HBoxContainer/z_rot.value = rad2deg(selected_object.global_rotation.z)
+
+
+func _on_x_value_changed(value):
+	if is_instance_valid(selected_object):
+		if local_mode:
+			selected_object.translation.x = value
+		else:
+			selected_object.global_translation.x = value
+
+
+func _on_y_value_changed(value):
+	if is_instance_valid(selected_object):
+		if local_mode:
+			selected_object.translation.y = value
+		else:
+			selected_object.global_translation.y = value
+
+
+func _on_z_value_changed(value):
+	if is_instance_valid(selected_object):
+		if local_mode:
+			selected_object.translation.z = value
+		else:
+			selected_object.global_translation.z = value
+
+
+func _on_x_rot_value_changed(value: float):
+	if is_instance_valid(selected_object):
+		if local_mode:
+			selected_object.rotation.x = deg2rad(value)
+		else:
+			selected_object.global_rotation.x = deg2rad(value)
+
+
+func _on_y_rot_value_changed(value: float):
+	if is_instance_valid(selected_object):
+		if local_mode:
+			selected_object.rotation.y = deg2rad(value)
+		else:
+			selected_object.global_rotation.y = deg2rad(value)
+
+
+func _on_z_rot_value_changed(value: float):
+	if is_instance_valid(selected_object):
+		if local_mode:
+			selected_object.rotation.z = deg2rad(value)
+		else:
+			selected_object.global_rotation.z = deg2rad(value)
+
+
+func _on_local_toggled(is_local: bool) -> void:
+	local_mode = is_local
+	for child in selected_object.get_children():
+		var gizmo := child as Gizmo
+		if not gizmo:
+			continue
+		gizmo.local_mode = is_local
+		break
+
+
+func _on_selected_object_changed(new_object, type_string) -> void:
+	selected_object = new_object
+	selected_type = type_string
+	visible = selected_type in ["Building", "Rail"]

--- a/src/project.godot
+++ b/src/project.godot
@@ -144,6 +144,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://Data/Scripts/Singletons/file_tools.gd"
 }, {
+"base": "Spatial",
+"class": "Gizmo",
+"language": "GDScript",
+"path": "res://Editor/Scripts/Gizmo.gd"
+}, {
 "base": "Button",
 "class": "InputButton",
 "language": "GDScript",
@@ -203,6 +208,11 @@ _global_script_classes=[ {
 "class": "ObjectGroup",
 "language": "GDScript",
 "path": "res://Data/Scripts/Resources/object_group.gd"
+}, {
+"base": "PanelContainer",
+"class": "ObjectTransform",
+"language": "GDScript",
+"path": "res://Editor/ui/object_transform.gd"
 }, {
 "base": "RailLogic",
 "class": "PZBMagnet",
@@ -427,6 +437,7 @@ _global_script_class_icons={
 "EditorInfo": "",
 "ExportTrack": "",
 "FileTools": "",
+"Gizmo": "",
 "InputButton": "",
 "InputLabel": "",
 "InputMapResource": "",
@@ -439,6 +450,7 @@ _global_script_class_icons={
 "Map": "",
 "ModContentDefinition": "",
 "ObjectGroup": "",
+"ObjectTransform": "",
 "PZBMagnet": "",
 "PassengerPathNode": "",
 "Pause": "",


### PR DESCRIPTION
I wanted to finish the last station of Hainfurt...
First, when I positioned a building and saved, it was gone and not to be found. Turns out, we move buildings between chunks but don't retain their global position.

Then I wanted to move a building and it was 1000 metres elsewhere. Also rotating and then moving something close to tracks wasn't fun. That's where the local transform mode comes from. And the position input code was such mess that I need to clean it up. Sorry (not sorry) :D


- Gizmo: Fix local to global offset when moving
- Editor: Add local transform mode
- Saving: Ensure buildings stay at their position
- Fix whitespace

PS: Hainfurt wasn't developed today. 🙈 