### PR TITLE
Fix: prepend file schema to open content folder path on macOS

### DIFF
--- a/src/Data/UI/Content.gd
+++ b/src/Data/UI/Content.gd
@@ -31,7 +31,4 @@ func _on_Back_pressed() -> void:
 
 
 func _on_Open_pressed() -> void:
-	var addonPath = ProjectSettings.globalize_path("user://addons/")
-	if OS.get_name() == "OSX":
-		addonPath = "file://" + addonPath
-	var _unused = OS.shell_open(addonPath)
+	var _unused = OS.shell_open("file://" + ProjectSettings.globalize_path("user://addons/"))

--- a/src/Data/UI/Content.gd
+++ b/src/Data/UI/Content.gd
@@ -31,4 +31,7 @@ func _on_Back_pressed() -> void:
 
 
 func _on_Open_pressed() -> void:
-	var _unused = OS.shell_open(ProjectSettings.globalize_path("user://addons/"))
+	var addonPath = ProjectSettings.globalize_path("user://addons/")
+	if OS.get_name() == "OSX":
+		addonPath = "file://" + addonPath
+	var _unused = OS.shell_open(addonPath)


### PR DESCRIPTION
Resolves #552

Prepending file schema to open content folder path. This will still work on Windows and other OSs.
If someone can check if always prepending `"file://"` also works on other platforms there would not be the need for this kind of workaround.