### PR TITLE
Fix safety systems error with ai trains

### DIFF
--- a/src/Data/Scripts/PZBModule.gd
+++ b/src/Data/Scripts/PZBModule.gd
@@ -65,7 +65,8 @@ func _on_settings_changed() -> void:
 	#   connect "settings changed" signal, then re-check if pzb is on
 	#   in case the player toggles it in the pause-menu options menu
 
-	var is_pzb_enabled: bool = (not Root.EasyMode) and jSettings.get_pzb()
+	# If the train is an ai train, the "Player" node can't be found and player is null => disable PZB
+	var is_pzb_enabled: bool = (not Root.EasyMode) and jSettings.get_pzb() and player != null
 
 	if is_pzb_enabled:
 		pzb_reset()

--- a/src/Data/Scripts/SifaModule.gd
+++ b/src/Data/Scripts/SifaModule.gd
@@ -19,7 +19,8 @@ func _on_settings_changed() -> void:
 	#   connect "settings changed" signal, then re-check if sifa is on
 	#   in case the player toggles it in the pause-menu options menu
 
-	is_sifa_enabled = (not Root.EasyMode) and jSettings.get_sifa()
+	# If the train is an ai train, the "Player" node can't be found and player is null => disable Sifa
+	is_sifa_enabled = (not Root.EasyMode) and jSettings.get_sifa() and player != null
 	set_process(is_sifa_enabled)
 	set_process_unhandled_input(is_sifa_enabled)
 


### PR DESCRIPTION
On ai trains, the Node of type LTSPlayer is not called "Player" and the safety systems get the player node by name.

This fix disables the Saftey Systems if the player node is null, as they shouldn't be enabled in ai trains anyways. This isn't a clean solution, but it's uncomplicated.

Other solutions would be
- to export the player variable (you would have to connect it manually, but the PZB signals also have to be connected manually at the moment)
- or to have it set by the player maybe as part of the SafetySystems class.

The last one is my favourite, as every safety system will have to have access to the player, but I'm not sure and I'd love to hear you opinion