### PR TITLE
Add scenario time of day and weather

### DIFF
--- a/src/Data/Scripts/Resources/track_scenario.gd
+++ b/src/Data/Scripts/Resources/track_scenario.gd
@@ -1,6 +1,12 @@
 class_name TrackScenario
 extends Resource
 
+enum Weather {
+	CLEAR,
+	RAIN,
+	SNOW,
+}
+
 
 export (int) var time: int = 0  # seconds
 export (String) var title := ""
@@ -8,6 +14,8 @@ export (String) var description := ""
 export (int) var duration: int = 0  # minutes
 
 export (bool) var is_hidden := false  # true = visible only in Editor, not in Play menu
+export (int, "Clear", "Rain", "Snow") var weather: int = Weather.CLEAR
+export (bool) var dynamic_time_of_day := false
 
 # Dict[String, ScenarioRoute]
 export (Dictionary) var routes := {}

--- a/src/Data/Scripts/World.gd
+++ b/src/Data/Scripts/World.gd
@@ -1,6 +1,13 @@
 class_name LTSWorld  # you can probably never use this, because it just causes cyclic dependency :^)
 extends Spatial
 
+const DAY_SECONDS := 24 * 60 * 60
+const WEATHER_CLEAR := 0
+const WEATHER_RAIN := 1
+const WEATHER_SNOW := 2
+const WEATHER_RADIUS := 85.0
+const WEATHER_HEIGHT := 45.0
+
 var timeMSeconds: float = 0 # Just used for counting every second
 var time: int = 0 # Unit: seconds (from 00:00:00)
 
@@ -29,6 +36,12 @@ var _person_visual_instances := [
 ]
 
 var chunk_manager: ChunkManager = null
+
+var _scenario_start_time: int = 0
+var _scenario_environment_prepared := false
+var _last_environment_time := -1
+var _weather_particles: Particles = null
+var _weather_particle_mode := -1
 
 # If the World is just use as data source (e.g. for scenario editor)
 var passive := false
@@ -80,7 +93,9 @@ func _ready() -> void:
 
 	player = $Players/Player
 	assert(player)
+	_get_scenario_environment()
 	apply_user_settings()
+	_apply_scenario_environment(true)
 
 	player.update_waiting_persons_on_next_station()
 
@@ -112,6 +127,7 @@ func _process(delta: float) -> void:
 	if not Root.Editor:
 		advance_time(delta)
 		check_train_spawn(delta)
+		_apply_scenario_environment()
 
 
 func advance_time(delta: float) -> void:
@@ -134,8 +150,11 @@ func set_scenario_to_world() -> void:
 	current_scenario = TrackScenario.load_scenario()
 	assert(current_scenario != null)
 
-	# Apply General Settins
-	time = Root.selected_time
+	# Apply General Settings
+	_scenario_start_time = Root.selected_time
+	if _scenario_start_time < 0:
+		_scenario_start_time = current_scenario.time
+	time = _scenario_start_time
 
 	# Apply Signal Data
 	var rail_logic_data = current_scenario.rail_logic_settings
@@ -159,7 +178,7 @@ func set_scenario_to_world() -> void:
 
 		var minimal_platform_length: int = route.get_minimal_platform_length(self)
 		var train_rail_route: Array = route.get_calculated_rail_route(self)
-		var train_station_table: Array = route.get_calculated_station_points(Root.selected_time)
+		var train_station_table: Array = route.get_calculated_station_points(time)
 		var despawn_point: RoutePoint = route.get_despawn_point()
 		var available_times: Array = route.get_start_times()
 
@@ -189,6 +208,191 @@ func set_scenario_to_world() -> void:
 			routes[Root.selected_route].description.empty() \
 			else tr(routes[Root.selected_route].description)
 	jEssentials.call_delayed(1, $Players/Player, "show_textbox_message", [description])
+
+
+func _apply_scenario_environment(force := false) -> void:
+	if current_scenario == null or Root.Editor:
+		return
+
+	var visual_time := time if current_scenario.dynamic_time_of_day else _scenario_start_time
+	if force or visual_time != _last_environment_time:
+		var environment := _get_scenario_environment()
+		var sunlight := get_node_or_null("DirectionalLight") as DirectionalLight
+		if environment != null:
+			_apply_time_of_day(environment, sunlight, visual_time)
+		_last_environment_time = visual_time
+
+	_update_weather_particles()
+
+
+func _get_scenario_environment() -> Environment:
+	if not has_node("WorldEnvironment"):
+		return null
+
+	var environment_node := $WorldEnvironment as WorldEnvironment
+	if environment_node.environment == null:
+		return null
+
+	if not _scenario_environment_prepared:
+		var environment := environment_node.environment.duplicate(true) as Environment
+		if environment.background_sky != null:
+			environment.background_sky = environment.background_sky.duplicate(true)
+		environment_node.environment = environment
+		_scenario_environment_prepared = true
+
+	return environment_node.environment
+
+
+func _apply_time_of_day(environment: Environment, sunlight: DirectionalLight, seconds: int) -> void:
+	var normalized_seconds := int(seconds) % DAY_SECONDS
+	if normalized_seconds < 0:
+		normalized_seconds += DAY_SECONDS
+
+	var hour := float(normalized_seconds) / 3600.0
+	var sun_height := sin(((hour - 6.0) / 12.0) * PI)
+	var daylight := clamp((sun_height + 0.15) / 0.55, 0.0, 1.0)
+	var twilight := clamp(1.0 - abs(sun_height) / 0.25, 0.0, 1.0)
+	var weather := int(current_scenario.weather)
+
+	var night_color := Color(0.08, 0.10, 0.18, 1.0)
+	var day_color := Color(1.0, 0.96, 0.90, 1.0)
+	var twilight_color := Color(1.0, 0.56, 0.34, 1.0)
+	var light_color := night_color.linear_interpolate(day_color, daylight)
+	light_color = light_color.linear_interpolate(twilight_color, twilight * (1.0 - daylight * 0.35))
+	var light_energy := lerp(0.05, 1.15, daylight)
+
+	match weather:
+		WEATHER_RAIN:
+			light_color = light_color.linear_interpolate(Color(0.60, 0.66, 0.74, 1.0), 0.45)
+			light_energy *= 0.55
+		WEATHER_SNOW:
+			light_color = light_color.linear_interpolate(Color(0.84, 0.90, 1.0, 1.0), 0.35)
+			light_energy *= 0.75
+
+	if sunlight != null:
+		var altitude := lerp(-22.0, 68.0, max(sun_height, 0.0))
+		var azimuth := (float(normalized_seconds) / float(DAY_SECONDS)) * 360.0 - 90.0
+		sunlight.rotation_degrees = Vector3(-altitude, azimuth, 0.0)
+		sunlight.light_color = light_color
+		sunlight.light_energy = light_energy
+
+	environment.background_energy = lerp(0.12, 1.0, daylight)
+	environment.ambient_light_color = night_color.linear_interpolate(day_color, clamp(daylight + 0.15, 0.0, 1.0))
+	environment.ambient_light_energy = lerp(0.22, 0.75, daylight)
+	environment.adjustment_enabled = true
+	environment.adjustment_saturation = 1.0
+
+	var sky = environment.background_sky
+	if sky is ProceduralSky:
+		var sky_top := Color(0.04, 0.06, 0.14, 1.0).linear_interpolate(Color(0.51, 0.68, 0.82, 1.0), daylight)
+		var sky_horizon := Color(0.08, 0.09, 0.16, 1.0).linear_interpolate(Color(0.80, 0.87, 0.91, 1.0), daylight)
+		sky_top = sky_top.linear_interpolate(twilight_color, twilight * 0.35)
+		sky_horizon = sky_horizon.linear_interpolate(twilight_color, twilight * 0.55)
+		sky.sky_top_color = sky_top
+		sky.sky_horizon_color = sky_horizon
+		sky.ground_bottom_color = sky_horizon
+		sky.ground_horizon_color = sky_horizon
+		sky.sun_latitude = clamp(lerp(-20.0, 58.0, max(sun_height, 0.0)), -20.0, 58.0)
+		sky.sun_longitude = (float(normalized_seconds) / float(DAY_SECONDS)) * 360.0
+		sky.sun_energy = light_energy * 3.0
+
+	if Root.mobile_version:
+		return
+
+	match weather:
+		WEATHER_RAIN:
+			environment.fog_enabled = true
+			environment.fog_color = Color(0.39, 0.43, 0.48, 1.0)
+			environment.fog_sun_color = Color(0.62, 0.67, 0.72, 1.0)
+			environment.fog_depth_begin = 50.0
+			environment.fog_depth_end = 420.0
+			environment.background_energy *= 0.72
+			environment.adjustment_saturation = 0.72
+		WEATHER_SNOW:
+			environment.fog_enabled = true
+			environment.fog_color = Color(0.80, 0.85, 0.90, 1.0)
+			environment.fog_sun_color = Color(0.92, 0.95, 1.0, 1.0)
+			environment.fog_depth_begin = 35.0
+			environment.fog_depth_end = 360.0
+			environment.background_energy *= 0.85
+			environment.adjustment_saturation = 0.82
+		_:
+			environment.fog_enabled = ProjectSettings["game/graphics/fog"]
+			environment.fog_color = Color(1.0, 1.0, 1.0, 1.0)
+			environment.fog_sun_color = Color(1.0, 1.0, 1.0, 1.0)
+			environment.fog_depth_begin = 156.3
+			environment.fog_depth_end = 766.7
+
+
+func _update_weather_particles() -> void:
+	if current_scenario == null:
+		return
+
+	var weather := int(current_scenario.weather)
+	if weather == WEATHER_CLEAR or Root.mobile_version:
+		_clear_weather_particles()
+		return
+
+	if _weather_particles == null:
+		_weather_particles = Particles.new()
+		_weather_particles.name = "ScenarioWeather"
+		add_child(_weather_particles)
+
+	if _weather_particle_mode != weather:
+		_configure_weather_particles(weather)
+
+	var target := player if is_instance_valid(player) else null
+	if target != null:
+		var origin: Vector3 = target.global_transform.origin
+		origin.y += WEATHER_HEIGHT
+		_weather_particles.global_transform.origin = origin
+
+	_weather_particles.emitting = true
+
+
+func _configure_weather_particles(weather: int) -> void:
+	_weather_particle_mode = weather
+	_weather_particles.amount = 900 if weather == WEATHER_RAIN else 450
+	_weather_particles.lifetime = 1.4 if weather == WEATHER_RAIN else 4.0
+	_weather_particles.preprocess = _weather_particles.lifetime
+	_weather_particles.local_coords = false
+	_weather_particles.visibility_aabb = AABB(
+		Vector3(-WEATHER_RADIUS, -WEATHER_HEIGHT, -WEATHER_RADIUS),
+		Vector3(WEATHER_RADIUS * 2.0, WEATHER_HEIGHT * 2.0, WEATHER_RADIUS * 2.0)
+	)
+
+	var particle_material := ParticlesMaterial.new()
+	particle_material.emission_shape = ParticlesMaterial.EMISSION_SHAPE_BOX
+	particle_material.emission_box_extents = Vector3(WEATHER_RADIUS, 1.0, WEATHER_RADIUS)
+	particle_material.direction = Vector3(0.0, -1.0, 0.0)
+	particle_material.spread = 7.0 if weather == WEATHER_RAIN else 45.0
+
+	var mesh := CubeMesh.new()
+	var mesh_material := SpatialMaterial.new()
+	mesh_material.flags_unshaded = true
+
+	if weather == WEATHER_RAIN:
+		particle_material.gravity = Vector3(4.0, -42.0, 0.0)
+		particle_material.initial_velocity = 25.0
+		mesh.size = Vector3(0.025, 0.75, 0.025)
+		mesh_material.albedo_color = Color(0.62, 0.74, 0.95, 0.62)
+	else:
+		particle_material.gravity = Vector3(1.5, -4.0, 0.0)
+		particle_material.initial_velocity = 2.0
+		mesh.size = Vector3(0.12, 0.12, 0.12)
+		mesh_material.albedo_color = Color(1.0, 1.0, 1.0, 0.86)
+
+	mesh.material = mesh_material
+	_weather_particles.process_material = particle_material
+	_weather_particles.draw_pass_1 = mesh
+
+
+func _clear_weather_particles() -> void:
+	_weather_particle_mode = -1
+	if _weather_particles == null:
+		return
+	_weather_particles.queue_free()
+	_weather_particles = null
 
 
 func spawn_train(train_spawn_information: TrainSpawnInformation) -> void:

--- a/src/Editor/Scripts/ScenarioConfiguration.gd
+++ b/src/Editor/Scripts/ScenarioConfiguration.gd
@@ -1,5 +1,8 @@
 extends Panel
 
+const TIME_FIELD_SCENE := preload("res://Editor/Modules/TimeField.tscn")
+const WEATHER_NAMES := ["Clear", "Rain", "Snow"]
+
 # local cache of things edited
 var routes: Dictionary = {}
 var rail_logic_settings: Dictionary = {}
@@ -16,6 +19,7 @@ onready var content_selector = get_parent().get_node("Content_Selector")
 func init():
 	scenario_editor = find_parent("ScenarioEditor")
 	world = scenario_editor.get_node("World")
+	_create_scenario_settings_ui()
 
 	routes = scenario_editor.scenario_info.routes.duplicate(true)
 	rail_logic_settings = scenario_editor.scenario_info.rail_logic_settings.duplicate(true)
@@ -31,6 +35,7 @@ func init():
 					rail_logic_settings[signal_instance.name] = StationSettings.new()
 
 	update_route_list()
+	update_scenario_settings_ui()
 	update_rail_logic_ui()
 	world.write_station_data(rail_logic_settings)
 
@@ -48,6 +53,7 @@ func save():
 
 
 func _ready():
+	_create_scenario_settings_ui()
 	update_ui_for_current_route()
 
 
@@ -66,6 +72,84 @@ func show_selection_message(text: String) -> void:
 
 func hide_selection_message() -> void:
 	get_parent().get_node("SelectMessage").hide()
+
+
+func _create_scenario_settings_ui() -> void:
+	if has_node("TabContainer/Scenario"):
+		return
+
+	var scenario_tab := VBoxContainer.new()
+	scenario_tab.name = "Scenario"
+	scenario_tab.anchor_right = 1.0
+	scenario_tab.anchor_bottom = 1.0
+	scenario_tab.margin_left = 4.0
+	scenario_tab.margin_top = 32.0
+	scenario_tab.margin_right = -4.0
+	scenario_tab.margin_bottom = -4.0
+	$TabContainer.add_child(scenario_tab)
+	$TabContainer.move_child(scenario_tab, 0)
+
+	var grid := GridContainer.new()
+	grid.name = "Grid"
+	grid.columns = 2
+	grid.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scenario_tab.add_child(grid)
+
+	var start_time_label := Label.new()
+	start_time_label.text = "Fallback Start Time"
+	grid.add_child(start_time_label)
+
+	var start_time := TIME_FIELD_SCENE.instance()
+	start_time.name = "StartTime"
+	start_time.rect_min_size = Vector2(0, 20)
+	start_time.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	start_time.connect("time_set", self, "_on_Scenario_StartTime_time_set")
+	grid.add_child(start_time)
+
+	var weather_label := Label.new()
+	weather_label.text = "Weather"
+	grid.add_child(weather_label)
+
+	var weather := OptionButton.new()
+	weather.name = "Weather"
+	weather.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	for i in range(WEATHER_NAMES.size()):
+		weather.add_item(WEATHER_NAMES[i], i)
+	weather.connect("item_selected", self, "_on_Scenario_Weather_item_selected")
+	grid.add_child(weather)
+
+	var dynamic_time_label := Label.new()
+	dynamic_time_label.text = "Dynamic Time of Day"
+	grid.add_child(dynamic_time_label)
+
+	var dynamic_time := CheckBox.new()
+	dynamic_time.name = "DynamicTimeOfDay"
+	dynamic_time.connect("pressed", self, "_on_Scenario_DynamicTimeOfDay_pressed")
+	grid.add_child(dynamic_time)
+
+
+func update_scenario_settings_ui() -> void:
+	if scenario_editor == null or scenario_editor.scenario_info == null:
+		return
+	if not has_node("TabContainer/Scenario"):
+		return
+
+	var scenario_info: TrackScenario = scenario_editor.scenario_info
+	$TabContainer/Scenario/Grid/StartTime.set_data_in_seconds(scenario_info.time)
+	$TabContainer/Scenario/Grid/Weather.select(int(clamp(scenario_info.weather, 0, WEATHER_NAMES.size() - 1)))
+	$TabContainer/Scenario/Grid/DynamicTimeOfDay.pressed = scenario_info.dynamic_time_of_day
+
+
+func _on_Scenario_StartTime_time_set() -> void:
+	scenario_editor.scenario_info.time = $TabContainer/Scenario/Grid/StartTime.get_data_in_seconds()
+
+
+func _on_Scenario_Weather_item_selected(index: int) -> void:
+	scenario_editor.scenario_info.weather = index
+
+
+func _on_Scenario_DynamicTimeOfDay_pressed() -> void:
+	scenario_editor.scenario_info.dynamic_time_of_day = $TabContainer/Scenario/Grid/DynamicTimeOfDay.pressed
 
 
 func _on_Routes_user_added_entry(entry_name):


### PR DESCRIPTION
## Summary

- Add scenario resource fields for weather and dynamic time-of-day behavior.
- Apply scenario start time to world lighting, sky, ambient light, and fog.
- Add rain and snow effects, plus scenario editor controls for the new settings.

Closes #106

## Validation

- `git diff --check`
- Godot 3.6 runtime probes for the new environment, sky, particles, mesh, and node APIs
- Full project parsing is currently blocked locally by missing generated/imported resources and existing autoload/class errors in this checkout.
